### PR TITLE
Print response.body if status code is incorrect

### DIFF
--- a/lib/generators/graphiti/templates/create_request_spec.rb.erb
+++ b/lib/generators/graphiti/templates/create_request_spec.rb.erb
@@ -21,8 +21,8 @@ RSpec.describe "<%= type %>#create", type: :request do
       expect(<%= resource_class %>).to receive(:build).and_call_original
       expect {
         make_request
+        expect(response.status).to eq(201), response.body
       }.to change { <%= model_class %>.count }.by(1)
-      expect(response.status).to eq(201)
     end
   end
 end

--- a/lib/generators/graphiti/templates/destroy_request_spec.rb.erb
+++ b/lib/generators/graphiti/templates/destroy_request_spec.rb.erb
@@ -10,10 +10,12 @@ RSpec.describe "<%= type %>#destroy", type: :request do
 
     it 'updates the resource' do
       expect(<%= resource_class %>).to receive(:find).and_call_original
-      expect { make_request }.to change { <%= model_class %>.count }.by(-1)
+      expect {
+        make_request
+        expect(response.status).to eq(200), response.body
+      }.to change { <%= model_class %>.count }.by(-1)
       expect { <%= var %>.reload }
         .to raise_error(ActiveRecord::RecordNotFound)
-      expect(response.status).to eq(200)
       expect(json).to eq('meta' => {})
     end
   end

--- a/lib/generators/graphiti/templates/index_request_spec.rb.erb
+++ b/lib/generators/graphiti/templates/index_request_spec.rb.erb
@@ -14,7 +14,7 @@ RSpec.describe "<%= type %>#index", type: :request do
     it 'works' do
       expect(<%= resource_class %>).to receive(:all).and_call_original
       make_request
-      expect(response.status).to eq(200)
+      expect(response.status).to eq(200), response.body
       expect(d.map(&:jsonapi_type).uniq).to match_array(['<%= type %>'])
       expect(d.map(&:id)).to match_array([<%= var %>1.id, <%= var %>2.id])
     end

--- a/lib/generators/graphiti/templates/update_request_spec.rb.erb
+++ b/lib/generators/graphiti/templates/update_request_spec.rb.erb
@@ -25,8 +25,8 @@ RSpec.describe "<%= type %>#update", type: :request do
       expect(<%= resource_class %>).to receive(:find).and_call_original
       expect {
         make_request
+        expect(response.status).to eq(200), response.body
       }.to change { <%= var %>.reload.attributes }
-      expect(response.status).to eq(200)
     end
   end
 end


### PR DESCRIPTION
Show the error messages in failed specs when create/update/delete
fails.