### PR TITLE
Let filters accept non-array `only` and `except`

### DIFF
--- a/lib/graphiti/filter_operators.rb
+++ b/lib/graphiti/filter_operators.rb
@@ -7,10 +7,10 @@ module Graphiti
         @procs = {}
         defaults = resource.adapter.default_operators[type_name] || [:eq]
         if opts[:only]
-          defaults = defaults.select { |op| opts[:only].include?(op) }
+          defaults = defaults.select { |op| Array(opts[:only]).include?(op) }
         end
         if opts[:except]
-          defaults = defaults.reject { |op| opts[:except].include?(op) }
+          defaults = defaults.reject { |op| Array(opts[:except]).include?(op) }
         end
         defaults.each do |op|
           @procs[op] = nil

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -1106,6 +1106,16 @@ RSpec.describe 'filtering' do
           expect(resource.filters[:foo][:operators].keys).to eq([:eq, :foo])
         end
       end
+
+      context 'when only argument is not an array' do
+        before do
+          resource.filter :foo, :string, only: :eq
+        end
+
+        it 'limits available operators' do
+          expect(resource.filters[:foo][:operators].keys).to eq([:eq])
+        end
+      end
     end
 
     context 'and given :except option' do
@@ -1136,6 +1146,18 @@ RSpec.describe 'filtering' do
         it 'limits available operators, adding custom ones' do
           expect(resource.filters[:foo][:operators].keys).to eq([
             :gt, :gte, :lt, :lte, :foo
+          ])
+        end
+      end
+
+      context 'when except argument is not an array' do
+        before do
+          resource.filter :foo, :integer, except: :eq
+        end
+
+        it 'limits available operators' do
+          expect(resource.filters[:foo][:operators].keys).to eq([
+            :not_eq, :gt, :gte, :lt, :lte
           ])
         end
       end


### PR DESCRIPTION
This matches behavior in similar Rails APIs and is a small consistency
improvement.