### PR TITLE
Let resource callbacks use singular `only` args

### DIFF
--- a/lib/graphiti/resource/persistence.rb
+++ b/lib/graphiti/resource/persistence.rb
@@ -65,7 +65,7 @@ module Graphiti
         def add_callback(kind, lifecycle, method = nil, only, &blk)
           config[:callbacks][kind] ||= {}
           config[:callbacks][kind][lifecycle] ||= []
-          config[:callbacks][kind][lifecycle] << { callback: (method || blk), only: only }
+          config[:callbacks][kind][lifecycle] << { callback: (method || blk), only: Array(only) }
         end
       end
 


### PR DESCRIPTION
Matches Rails' conventions.