### PR TITLE
Pass in the method to the before_commit hook

### DIFF
--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -112,7 +112,7 @@ module Graphiti
 
     def before_commit(model, method)
       hook = self.class.config[:before_commit][method]
-      hook.call(model) if hook
+      hook.call(model, method) if hook
     end
 
     def transaction

--- a/spec/integration/rails/before_commit_spec.rb
+++ b/spec/integration/rails/before_commit_spec.rb
@@ -62,10 +62,12 @@ if ENV["APPRAISAL_INITIALIZED"]
 
         attribute :first_name, :string
 
-        before_commit only: [:create] do |employee|
-          Callbacks.add(:create, employee)
-          if $raise_on_before_commit[:employee]
-            raise 'rollitback'
+        before_commit only: [:create] do |employee, method|
+          if method == :create
+            Callbacks.add(:create, employee)
+            if $raise_on_before_commit[:employee]
+              raise 'rollitback'
+            end
           end
         end
 


### PR DESCRIPTION
There might be different conditions under which the client would like to raise an exception depending on the method (e.g. :create vs :destroy).