### PR TITLE
Assign correctly on string/integer mismatch

### DIFF
--- a/lib/graphiti/sideload/belongs_to.rb
+++ b/lib/graphiti/sideload/belongs_to.rb
@@ -48,6 +48,16 @@ class Graphiti::Sideload::BelongsTo < Graphiti::Sideload
   end
 
   def children_for(parent, map)
-    map[parent.send(foreign_key)]
+    fk = parent.send(foreign_key)
+    children = map[fk]
+    return children if children
+
+    keys = map.keys
+    if fk.is_a?(String) && keys[0].is_a?(Integer)
+      fk = fk.to_i
+    elsif fk.is_a?(Integer) && keys[0].is_a?(String)
+      fk = fk.to_s
+    end
+    map[fk] || []
   end
 end

--- a/lib/graphiti/sideload/has_many.rb
+++ b/lib/graphiti/sideload/has_many.rb
@@ -21,6 +21,16 @@ class Graphiti::Sideload::HasMany < Graphiti::Sideload
   end
 
   def children_for(parent, map)
-    map[parent.send(primary_key)] || []
+    pk = parent.send(primary_key)
+    children = map[pk]
+    return children if children
+
+    keys = map.keys
+    if pk.is_a?(String) && keys[0].is_a?(Integer)
+      pk = pk.to_i
+    elsif pk.is_a?(Integer) && keys[0].is_a?(String)
+      pk = pk.to_s
+    end
+    map[pk] || []
   end
 end

--- a/spec/sideload_spec.rb
+++ b/spec/sideload_spec.rb
@@ -330,6 +330,37 @@ RSpec.describe Graphiti::Sideload do
         expect(employees[0].positions).to eq(positions[0..1])
         expect(employees[1].positions).to eq([positions.last])
       end
+
+      context 'when match, but parent is integer and child is string' do
+        let(:positions) do
+          [
+            PORO::Position.new(id: 1, employee_id: '1'),
+            PORO::Position.new(id: 2, employee_id: '1'),
+            PORO::Position.new(id: 3, employee_id: '2')
+          ]
+        end
+
+        it 'still works' do
+          instance.assign(employees, positions)
+          expect(employees[0].positions).to eq(positions[0..1])
+          expect(employees[1].positions).to eq([positions.last])
+        end
+      end
+
+      context 'when match, but parent is string and child is integer' do
+        let(:employees) do
+          [
+            PORO::Employee.new(id: '1'),
+            PORO::Employee.new(id: '2')
+          ]
+        end
+
+        it 'still works' do
+          instance.assign(employees, positions)
+          expect(employees[0].positions).to eq(positions[0..1])
+          expect(employees[1].positions).to eq([positions.last])
+        end
+      end
     end
 
     context 'when a to-one relationship' do
@@ -358,6 +389,36 @@ RSpec.describe Graphiti::Sideload do
         instance.assign(positions, departments)
         expect(positions[0].department).to eq(departments[0])
         expect(positions[1].department).to eq(departments[1])
+      end
+
+      context 'when match, but parent is integer and child is string' do
+        let(:departments) do
+          [
+            PORO::Department.new(id: '1'),
+            PORO::Department.new(id: '2')
+          ]
+        end
+
+        it 'still works' do
+          instance.assign(positions, departments)
+          expect(positions[0].department).to eq(departments[0])
+          expect(positions[1].department).to eq(departments[1])
+        end
+      end
+
+      context 'when match, but child is string and parent is integer' do
+        let(:positions) do
+          [
+            PORO::Position.new(id: 1, department_id: '1'),
+            PORO::Position.new(id: 2, department_id: '2')
+          ]
+        end
+
+        it 'still works' do
+          instance.assign(positions, departments)
+          expect(positions[0].department).to eq(departments[0])
+          expect(positions[1].department).to eq(departments[1])
+        end
       end
     end
   end


### PR DESCRIPTION
Occasionally there's the scenario where the PK and FK have a
string/integer mismatch. The most common is with Remote Resources,
where the local API has an integer FK but the remote API has a string PK
(because all ids in JSONAPI are strings).