### PR TITLE
Treat empty strings for expected integers as nil

### DIFF
--- a/lib/graphiti/types.rb
+++ b/lib/graphiti/types.rb
@@ -57,23 +57,25 @@ module Graphiti
     end
 
     Integer = create(::Integer) do |input|
-      Dry::Types['coercible.integer'][input] if input
+      Dry::Types['coercible.integer'][input] unless input.blank?
     end
 
     # The Float() check here is to ensure we have a number
     # Otherwise BigDecimal('foo') *will return a decimal*
     ParamDecimal = create(::BigDecimal) do |input|
-      Float(input)
-      input = Dry::Types['coercible.decimal'][input]
-      Dry::Types['strict.decimal'][input]
+      unless input.blank?
+        Float(input)
+        input = Dry::Types['coercible.decimal'][input]
+        Dry::Types['strict.decimal'][input]
+      end
     end
 
     PresentInteger = create(::Integer) do |input|
-      Dry::Types['coercible.integer'][input]
+      Dry::Types['coercible.integer'][input] unless input.blank?
     end
 
     Float = create(::Float) do |input|
-      Dry::Types['coercible.float'][input] if input
+      Dry::Types['coercible.float'][input] unless input.blank?
     end
 
     PresentParamsHash = create(::Hash) do |input|

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -983,16 +983,14 @@ RSpec.describe 'persistence' do
         expect(save(nil)).to eq(nil)
       end
 
-      it 'does not coerce blank string to 0' do
-        expect {
-          save('')
-        }.to raise_error(Graphiti::Errors::TypecastFailed)
+      it 'coerces blank string to nil' do
+        expect(save('')).to eq(nil)
       end
 
       context 'when cannot coerce' do
         it 'raises error' do
           expect {
-            save({})
+            save('not-an-integer')
           }.to raise_error(Graphiti::Errors::TypecastFailed)
         end
       end
@@ -1013,6 +1011,10 @@ RSpec.describe 'persistence' do
 
       it 'allows nils' do
         expect(save(nil)).to eq(nil)
+      end
+
+      it 'coerces blank string to nil' do
+        expect(save('')).to eq(nil)
       end
 
       context 'when cannot coerce' do
@@ -1041,10 +1043,14 @@ RSpec.describe 'persistence' do
         expect(save(nil)).to eq(nil)
       end
 
+      it 'coerces blank string to nil' do
+        expect(save('')).to eq(nil)
+      end
+
       context 'when cannot coerce' do
         it 'raises error' do
           expect {
-            save({})
+            save('not-a-float')
           }.to raise_error(Graphiti::Errors::TypecastFailed)
         end
       end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -1515,7 +1515,7 @@ RSpec.describe Graphiti::Resource do
         end
 
         context 'when coercion fails' do
-          let(:value) { {} }
+          let(:value) { 'not-an-integer' }
 
           it 'raises helpful error' do
             expect {
@@ -1560,7 +1560,7 @@ RSpec.describe Graphiti::Resource do
       end
 
       context 'when coercion fails' do
-        let(:value) { {} }
+        let(:value) { 'not-an-integer' }
 
         it 'raises helpful error' do
           expect {
@@ -1580,7 +1580,7 @@ RSpec.describe Graphiti::Resource do
       end
 
       context 'when coercion fails' do
-        let(:value) { {} }
+        let(:value) { 'not-an-integer' }
 
         it 'raises helpful error' do
           expect {
@@ -1612,7 +1612,7 @@ RSpec.describe Graphiti::Resource do
       end
 
       context 'when coercion fails' do
-        let(:value) { {} }
+        let(:value) { 'not-an-integer' }
 
         it 'raises helpful error' do
           expect {

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe 'serialization' do
 
         context 'when cannot coerce' do
           before do
-            PORO::Employee.create(age: {})
+            PORO::Employee.create(age: 'not-a-float')
           end
 
           it 'raises error' do


### PR DESCRIPTION
Allow nullification of integer attributes when empty string is passed.