### PR TITLE
Added validation to the link generation in belongs_to so when the... 

### DIFF
--- a/lib/graphiti/util/link.rb
+++ b/lib/graphiti/util/link.rb
@@ -58,7 +58,12 @@ module Graphiti
         @path ||=
           path = @sideload.resource.endpoint[:url].to_s
           if @sideload.type == :belongs_to
-            path = "#{path}/#{@model.send(@sideload.foreign_key)}"
+            linked_resource_id = @model.send(@sideload.foreign_key)
+            if linked_resource_id
+              path = "#{path}/#{linked_resource_id}"
+            else
+              path = nil
+            end
           end
           path
       end

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -1220,6 +1220,16 @@ RSpec.describe 'serialization' do
           end
         end
 
+        context 'that is empty' do
+          let!(:employee) { PORO::Employee.create(classification_id: nil) }
+          it 'generates an empty link' do
+            resource.belongs_to :classification
+            render            
+            expect(classification['links']['related'])
+              .to eq(nil)
+          end
+        end
+
         # ie fields
         xit 'runtime options' do
         end


### PR DESCRIPTION
association is nil does not generate an index path.

I created a test before adding the changes:

```
 Failure/Error:
       expect(classification['links']['related'])
         .to eq(nil)

       expected: nil
            got: "/poro/classifications/"
```


And it's green after the changes.
