### PR TITLE
Allow polymorphic_belongs_to to ignore possible types

### DIFF
--- a/spec/fixtures/poro.rb
+++ b/spec/fixtures/poro.rb
@@ -11,6 +11,7 @@ module PORO
             bios: [],
             team_memberships: [],
             teams: [],
+            paypals: [],
             visas: [],
             mastercards: [],
             visa_rewards: [],
@@ -33,6 +34,7 @@ module PORO
           classifications: PORO::Classification,
           bios: PORO::Bio,
           teams: PORO::Team,
+          paypals: PORO::Paypal,
           visas: PORO::Visa,
           mastercards: PORO::Mastercard,
           visa_rewards: PORO::VisaReward,
@@ -182,6 +184,7 @@ module PORO
       :credit_card_id,
       :cc_id,
       :credit_card_type,
+      :payment_processor,
       :salary
 
     def initialize(*)
@@ -239,6 +242,10 @@ module PORO
 
   class VisaReward < Base
     attr_accessor :visa_id, :points
+  end
+
+  class Paypal < Base
+    attr_accessor :account_id
   end
 
   class Book < Base
@@ -427,6 +434,14 @@ module PORO
 
     def base_scope
       { type: :visa_rewards }
+    end
+  end
+
+  class PaypalResource < ApplicationResource
+    attribute :account_id, :integer
+
+    def base_scope
+      { type: :paypals }
     end
   end
 


### PR DESCRIPTION
By allowing possible types to be ignored, multiple polymorphic_belongs_to
relationships can be built from the same foreign key as well as just
ignoring certain types stored in the grouping field's data in general.

This allows for resource definitions with polymorphic_belongs_to definitions like:
```
# Call <employee resource uri>?include=credit_card,payment_processor

class EmployeeResource < ApplicationResource
  polymorphic_belongs_to :credit_card do
    group_by(:credit_card_type, exclude: [:Paypal]) do
      on(:Visa)
      on(:Mastercard)
    end
  end

  polymorphic_belongs_to :payment_processor do
    group_by(:credit_card_type, only: [:Paypal]) do
      on(:Paypal).belongs_to :payment_processor,
        resource: PaypalResource,
        foreign_key: :credit_card_id
    end
  end
end
```