### PR TITLE
Fix polymorphic remote queries

### DIFF
--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -210,24 +210,6 @@ module Graphiti
       not [false, 'false'].include?(@params[:paginate])
     end
 
-    # If this is a remote call, we don't care about local parents
-    def chain
-      if @resource.remote
-        top_remote_parent = parents.find { |p| p.resource.remote? }
-        [].tap do |chain|
-          parents.select { |p| p.resource.remote? }.each do |p|
-            chain << p.association_name unless p == top_remote_parent
-          end
-          immediate_parent = parents.reverse[0]
-          # This is not currently checking that it is a remote of the same API
-          chain << association_name if immediate_parent && immediate_parent.resource.remote
-          chain.compact
-        end.compact
-      else
-        parents.map(&:association_name).compact + [association_name].compact
-      end
-    end
-
     private
 
     # Try to find on this resource

--- a/lib/graphiti/sideload/polymorphic_belongs_to.rb
+++ b/lib/graphiti/sideload/polymorphic_belongs_to.rb
@@ -114,6 +114,7 @@ class Graphiti::Sideload::PolymorphicBelongsTo < Graphiti::Sideload::BelongsTo
   # but not others. Remove anything we don't support.
   def remove_invalid_sideloads(resource, query)
     query = query.dup
+    query.instance_variable_set(:@hash, nil)
     query.sideloads.each_pair do |key, value|
       unless resource.class.sideload(key)
         query.sideloads.delete(key)

--- a/lib/graphiti/util/remote_params.rb
+++ b/lib/graphiti/util/remote_params.rb
@@ -21,7 +21,7 @@ module Graphiti
         if include_hash = @query.include_hash.presence
           @params[:include] = trim_sideloads(include_hash)
         end
-        collect_params(@query)
+        collect_params(@query, @resource)
         @params[:sort] = @sorts.join(',') if @sorts.present?
         @params[:filter] = @filters if @filters.present?
         @params[:page] = @pagination if @pagination.present?
@@ -33,13 +33,32 @@ module Graphiti
 
       private
 
-      def collect_params(query)
+      # If this is a remote call, we don't care about local parents
+      # When polymorphic, query is top-level (ie, query.resource is
+      # the parent, not a child type implementation).
+      # This is why we pass BOTH the resource and the query
+      def query_chain(resource, query)
+        top_remote_parent = query.parents.find { |p| p.resource.remote? }
+        [].tap do |chain|
+          query.parents.select { |p| p.resource.remote? }.each do |p|
+            chain << p.association_name unless p == top_remote_parent
+          end
+          immediate_parent = query.parents.reverse[0]
+          # This is not currently checking that it is a remote of the same API
+          chain << query.association_name if immediate_parent && immediate_parent.resource.remote
+          chain.compact
+        end.compact
+      end
+
+      def collect_params(query, resource = nil)
         query_hash = query.hash
-        process_sorts(query_hash[:sort], query)
+        resource ||= query.resource
+        chain = query_chain(resource, query)
+        process_sorts(query_hash[:sort], chain)
         process_fields(query.fields.merge(query.hash[:fields] || {}))
         process_extra_fields(query.extra_fields.merge(query.hash[:extra_fields] || {}))
-        process_filters(query_hash[:filter], query)
-        process_pagination(query_hash[:page], query)
+        process_filters(query_hash[:filter], chain)
+        process_pagination(query_hash[:page], chain)
         process_stats(query_hash[:stats])
 
         query.sideloads.each_pair do |assn_name, nested_query|
@@ -54,22 +73,22 @@ module Graphiti
         @stats = { stats.keys.first => stats.values.join(',') }
       end
 
-      def process_pagination(page, query)
+      def process_pagination(page, chain)
         return unless page.present?
         if size = page[:size]
-          key = (query.chain + [:size]).join('.')
+          key = (chain + [:size]).join('.')
           @pagination[key.to_sym] = size
         end
         if number = page[:number]
-          key = (query.chain + [:number]).join('.')
+          key = (chain + [:number]).join('.')
           @pagination[key.to_sym] = number
         end
       end
 
-      def process_filters(filters, query)
+      def process_filters(filters, chain)
         return unless filters.present?
         filters.each_pair do |att, config|
-          att = (query.chain + [att]).join('.')
+          att = (chain + [att]).join('.')
           @filters[att.to_sym] = config
         end
       end
@@ -90,14 +109,14 @@ module Graphiti
         end
       end
 
-      def process_sorts(sorts, query)
+      def process_sorts(sorts, chain)
         return unless sorts
 
         if sorts.is_a?(String) # manually assigned
           @sorts << sorts
         else
           sorts.each do |s|
-            sort = (query.chain + [s.keys.first]).join('.')
+            sort = (chain + [s.keys.first]).join('.')
             sort = "-#{sort}" if s.values.first == :desc
             @sorts << sort
           end


### PR DESCRIPTION
There were two issues here.

The first was that the Query object references the top-level of the
polymorphic sideload (e.g. `credit_card`), and not the child type
implementation (e.g. `visa`). This is problematic when deriving the
query chain that we need to pass to the remote API. Solution is to move
the chain logic out of Query and into `Util::RemoteParams`, which is
where it was actually used and a better place for the code either way.

The second was with polymorphic relationships modifying the params. When
you modify params, we mutate `query.hash` - not a problem and even
desirable/correct for non-polymorphic associations. But when
polymorphic, that hash is going to be passed again to each sub-relation
(`mastercard`, `visa`, etc.). So mastercard modifies params, and visa
incorrectly gets that modification. Solution is to refresh `query.hash`
when processing each level of the polymorphic relation.