### PR TITLE
Fix issue with multiple sidepost destroys

### DIFF
--- a/lib/graphiti/util/validation_response.rb
+++ b/lib/graphiti/util/validation_response.rb
@@ -59,6 +59,8 @@ class Graphiti::Util::ValidationResponse
       if payload.is_a?(Array)
         related_objects = model.send(name)
         related_objects.each_with_index do |r, index|
+          method = payload[index].try(:[], :meta).try(:[], :method)
+          next if [nil, :destroy, :disassociate].include?(method)
           valid = valid_object?(r)
           checks << valid
 

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -957,5 +957,38 @@ if ENV["APPRAISAL_INITIALIZED"]
         expect(workspace.address).to eq('Fake Workspace Address')
       end
     end
+
+    describe 'delete nested item' do
+      subject(:make_request) { do_update(payload) }
+
+      let!(:employee)   { Employee.create!(first_name: 'original', positions: [position1, position2, position3]) }
+      let!(:position1)  { Position.create!(title: 'pos1') }
+      let!(:position2)  { Position.create!(title: 'pos2') }
+      let!(:position3)  { Position.create!(title: 'pos3') }
+
+      let(:path) { "/employees/#{employee.id}" }
+
+      let(:payload) do
+        {
+            data: {
+                id: employee.id,
+                type: 'employees',
+                attributes: { },
+                relationships: {
+                    positions: {
+                        data: [
+                            { type: 'positions', id: position2.id.to_s, method: 'destroy' }
+                        ]
+                    }
+                }
+            },
+        }
+      end
+
+      it 'works' do
+        expect(employee.positions.count).to eq(3)
+        expect {make_request}.to change { employee.positions.count }.by(-1)
+      end
+    end
   end
 end


### PR DESCRIPTION
When validating, we would iterate over the relationships and compare them to their spot
in the payload. This normally works because we iterate both the same
way. However, we never associate objects that have been destroyed or
disassociated - which means the comparison will be incorrect and even
blow up when multiple objects are being persisted.

The solution is to skip these guys when iterating. This means we don't
recursively validate a destroyed object's associations, so I'd like us to
move to a pattern closer to what's happening in `before_commit`. But
this solves the problem for now and makes anything else an extreme edge
case.

Addresses https://github.com/graphiti-api/graphiti/pull/77/files