### PR TITLE
Render nil link when belongs_to FK is nil

### DIFF
--- a/lib/graphiti/util/link.rb
+++ b/lib/graphiti/util/link.rb
@@ -14,10 +14,20 @@ module Graphiti
       end
 
       def generate
-        on_demand_links(raw_url)
+        if linkable?
+          on_demand_links(raw_url)
+        end
       end
 
       private
+
+      def linkable?
+        if @sideload.type == :belongs_to
+          not @model.send(@sideload.foreign_key).nil?
+        else
+          true
+        end
+      end
 
       def raw_url
         if @sideload.link_proc

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -1220,6 +1220,18 @@ RSpec.describe 'serialization' do
           end
         end
 
+        context 'that is empty' do
+          before do
+            employee.update_attributes(classification_id: nil)
+          end
+
+          it 'generates an empty link' do
+            resource.belongs_to :classification
+            render
+            expect(classification['links']['related']).to be_nil
+          end
+        end
+
         # ie fields
         xit 'runtime options' do
         end


### PR DESCRIPTION
The jsonapi-rb library is always going to render this section of the
payload (when applicable), but the actual URL should be `nil` when a
belongs_to relationship has a `nil` foreign key. This probably makes the
most sense, so clients can still parse the payload as normal, but we
don't render an invalid url.