### PR TITLE
Optionally yield metadata on persistence hooks

### DIFF
--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -114,9 +114,9 @@ module Graphiti
       adapter.resolve(scope)
     end
 
-    def before_commit(model, method)
-      hooks = self.class.config[:before_commit][method] || []
-      hooks.each { |hook| hook.call(model) }
+    def before_commit(model, metadata)
+      hook = self.class.config[:before_commit][metadata[:method]]
+      instance_exec(model, metadata, &hook) if hook
     end
 
     def transaction

--- a/lib/graphiti/resource/persistence.rb
+++ b/lib/graphiti/resource/persistence.rb
@@ -69,64 +69,64 @@ module Graphiti
         end
       end
 
-      def create(create_params)
+      def create(create_params, meta = nil)
         model_instance = nil
 
-        run_callbacks :persistence, :create, create_params do
-          run_callbacks :attributes, :create, create_params do |params|
-            model_instance = build(model)
-            assign_attributes(model_instance, params)
+        run_callbacks :persistence, :create, create_params, meta do
+          run_callbacks :attributes, :create, create_params, meta do |params|
+            model_instance = call_with_meta(:build, model, meta)
+            call_with_meta(:assign_attributes, model_instance, params, meta)
             model_instance
           end
 
-          run_callbacks :save, :create, model_instance do
-            model_instance = save(model_instance)
+          run_callbacks :save, :create, model_instance, meta do
+            model_instance = call_with_meta(:save, model_instance, meta)
           end
 
           model_instance
         end
       end
 
-      def update(update_params)
+      def update(update_params, meta = nil)
         model_instance = nil
         id = update_params.delete(:id)
 
-        run_callbacks :persistence, :update, update_params do
-          run_callbacks :attributes, :update, update_params do |params|
+        run_callbacks :persistence, :update, update_params, meta do
+          run_callbacks :attributes, :update, update_params, meta do |params|
             model_instance = self.class._find(params.merge(id: id)).data
-            assign_attributes(model_instance, params)
+            call_with_meta(:assign_attributes, model_instance, params, meta)
             model_instance
           end
 
-          run_callbacks :save, :update, model_instance do
-            model_instance = save(model_instance)
+          run_callbacks :save, :update, model_instance, meta do
+            model_instance = call_with_meta(:save, model_instance, meta)
           end
         end
 
         model_instance
       end
 
-      def destroy(id)
+      def destroy(id, meta = nil)
         model_instance = self.class._find(id: id).data
-        run_callbacks :destroy, :destroy, model_instance do
-          delete(model_instance)
+        run_callbacks :destroy, :destroy, model_instance, meta do
+          call_with_meta(:delete, model_instance, meta)
         end
         model_instance
       end
 
-      def build(model)
+      def build(model, meta = nil)
         adapter.build(model)
       end
 
-      def assign_attributes(model_instance, update_params)
+      def assign_attributes(model_instance, update_params, meta = nil)
         adapter.assign_attributes(model_instance, update_params)
       end
 
-      def save(model_instance)
+      def save(model_instance, meta = nil)
         adapter.save(model_instance)
       end
 
-      def delete(model_instance)
+      def delete(model_instance, meta = nil)
         adapter.destroy(model_instance)
       end
 
@@ -136,7 +136,7 @@ module Graphiti
         fire_around_callbacks(kind, action, *args) do |*yieldargs|
           fire_callbacks(kind, :before, action, *yieldargs)
           result = yield(*yieldargs)
-          fire_callbacks(kind, :after, action, result)
+          fire_callbacks(kind, :after, action, *[result, args.last])
           result
         end
       end
@@ -147,13 +147,21 @@ module Graphiti
           callbacks.each do |config|
             callback = config[:callback]
             next unless config[:only].include?(action)
-
-            if callback.respond_to?(:call)
-              instance_exec(*args, &callback)
-            else
-              send(callback, *args)
-            end
+            call_with_meta(callback, *args)
           end
+        end
+      end
+
+      # Convenience for calling a method or proc
+      # while taking into account 'meta' is an optional argument
+      def call_with_meta(callback, *args)
+        if callback.respond_to?(:call)
+          instance_exec(*args, &callback)
+        else
+          arity = method(callback).arity
+          args = args[0..0] if arity == 1
+          args = args[0..1] if arity == 2
+          send(callback, *args)
         end
       end
 
@@ -177,6 +185,7 @@ module Graphiti
         if callbacks[index + 1]
           proc do
             r = nil
+            args = args[0..0] if method(method_name).arity == 1
             send(method_name, *args) do |r2|
               wrapped = around_callback_proc(callbacks, index+1, r2, &blk)
               r = instance_exec(r2, &wrapped)
@@ -184,9 +193,10 @@ module Graphiti
             r
           end
         else
-          proc do |result|
+          proc do |*args2|
             r = nil
-            send(callbacks[index][:callback], result) do |r2|
+            args2 = args2[0..0] if method(callbacks[index][:callback]).arity == 1
+            send(callbacks[index][:callback], *args2) do |r2|
               r = instance_exec(r2, &blk)
             end
             r

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -115,12 +115,13 @@ module Graphiti
 
     def destroy
       validator = @resource.transaction do
-        model = @resource.destroy(@query.filters[:id])
+        metadata = { method: :destroy }
+        model = @resource.destroy(@query.filters[:id], metadata)
         model.instance_variable_set(:@__serializer_klass, @resource.serializer)
         validator = ::Graphiti::Util::ValidationResponse.new \
           model, @payload
         validator.validate!
-        @resource.before_commit(model, :destroy)
+        @resource.before_commit(model, metadata)
         validator
       end
       @data, success = validator.to_a

--- a/lib/graphiti/util/persistence.rb
+++ b/lib/graphiti/util/persistence.rb
@@ -61,7 +61,7 @@ class Graphiti::Util::Persistence
 
     post_process(persisted, parents)
     post_process(persisted, children)
-    before_commit = -> { @resource.before_commit(persisted, @meta[:method]) }
+    before_commit = -> { @resource.before_commit(persisted, metadata) }
     add_hook(before_commit)
     persisted
   end
@@ -218,22 +218,23 @@ class Graphiti::Util::Persistence
     end
   end
 
-  # In the Resource, we want to allow:
-  #
-  # def create(attrs)
-  #
-  # and
-  #
-  # def create(attrs, parent = nil)
-  #
-  # 'parent' is an optional parameter that should not be part of the
-  # method signature in most use cases.
+  def metadata
+    {
+      method: @meta[:method],
+      temp_id: @meta[:temp_id],
+      caller_model: @caller_model,
+      attributes: @attributes,
+      relationships: @relationships
+    }
+  end
+
   def call_resource_method(method_name, attributes, caller_model)
     method = @resource.method(method_name)
-    if [2,-2].include?(method.arity)
-      method.call(attributes, caller_model)
-    else
+
+    if method.arity == 1
       method.call(attributes)
+    else
+      method.call(attributes, metadata)
     end
   end
 end


### PR DESCRIPTION
Now, all persistence hooks will optionally yield metadata - a hash
containing things like the method, temp id, further relationships,
the calling model in the graph. We can continue hanging things on
metadata as we get use cases.

The main use case is referencing the "caller model" - the parent in the
graph. If we're saving an Employee and her Positions in a single
request:

```ruby
class PositionResource < ApplicationResource
  before_commit do |position, meta|
    meta[:caller_model] # => #<Employee>
  end
end
```

This is also true for override methods `#build`, `#assign_attributes`,
`#save`, and `#destroy` - all now accept `meta` as an optional argument,
so it is accessible when overriding.

A notable case is `destroy`. We do not currently handle nested destroys,
and the code path for destroying a top-level entity is different than
when sideposting a deletion. We accomodate both use cases here, but
notable.