### PR TITLE
Support aliases for advanced filtering

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -37,7 +37,7 @@ module Graphiti
       alias :filter_uuid_not_eq :filter_not_eq
 
       def filter_string_eq(scope, attribute, value, is_not: false)
-        column = scope.klass.arel_table[attribute]
+        column = column_for(scope, attribute)
         clause = column.lower.eq_any(value.map(&:downcase))
         is_not ? scope.where.not(clause) : scope.where(clause)
       end
@@ -56,7 +56,7 @@ module Graphiti
       end
 
       def filter_string_prefix(scope, attribute, value, is_not: false)
-        column = scope.klass.arel_table[attribute]
+        column = column_for(scope, attribute)
         map = value.map { |v| "#{v}%" }
         clause = column.lower.matches_any(map)
         is_not ? scope.where.not(clause) : scope.where(clause)
@@ -67,7 +67,7 @@ module Graphiti
       end
 
       def filter_string_suffix(scope, attribute, value, is_not: false)
-        column = scope.klass.arel_table[attribute]
+        column = column_for(scope, attribute)
         map = value.map { |v| "%#{v}" }
         clause = column.lower.matches_any(map)
         is_not ? scope.where.not(clause) : scope.where(clause)
@@ -78,7 +78,7 @@ module Graphiti
       end
 
       def filter_string_match(scope, attribute, value, is_not: false)
-        column = scope.klass.arel_table[attribute]
+        column = column_for(scope, attribute)
         map = value.map { |v| "%#{v.downcase}%" }
         clause = column.lower.matches_any(map)
         is_not ? scope.where.not(clause) : scope.where(clause)
@@ -89,7 +89,7 @@ module Graphiti
       end
 
       def filter_gt(scope, attribute, value)
-        column = scope.klass.arel_table[attribute]
+        column = column_for(scope, attribute)
         scope.where(column.gt_any(value))
       end
       alias :filter_integer_gt :filter_gt
@@ -99,7 +99,7 @@ module Graphiti
       alias :filter_date_gt :filter_gt
 
       def filter_gte(scope, attribute, value)
-        column = scope.klass.arel_table[attribute]
+        column = column_for(scope, attribute)
         scope.where(column.gteq_any(value))
       end
       alias :filter_integer_gte :filter_gte
@@ -109,7 +109,7 @@ module Graphiti
       alias :filter_date_gte :filter_gte
 
       def filter_lt(scope, attribute, value)
-        column = scope.klass.arel_table[attribute]
+        column = column_for(scope, attribute)
         scope.where(column.lt_any(value))
       end
       alias :filter_integer_lt :filter_lt
@@ -119,7 +119,7 @@ module Graphiti
       alias :filter_date_lt :filter_lt
 
       def filter_lte(scope, attribute, value)
-        column = scope.klass.arel_table[attribute]
+        column = column_for(scope, attribute)
         scope.where(column.lteq_any(value))
       end
       alias :filter_integer_lte :filter_lte
@@ -271,6 +271,17 @@ module Graphiti
       def destroy(model_instance)
         model_instance.destroy
         model_instance
+      end
+
+      private
+
+      def column_for(scope, name)
+        table = scope.klass.arel_table
+        if other = scope.attribute_alias(name)
+          table[other]
+        else
+          table[name]
+        end
       end
     end
   end

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -96,6 +96,9 @@ module Legacy
     has_many :hobbies, through: :author_hobbies
     has_one :bio
 
+    alias_attribute :fname, :first_name
+    alias_attribute :birthdays, :age
+
     # This logic should not ever fire
     has_many :special_books,
       -> { where(id: 9999) },
@@ -262,7 +265,9 @@ module Legacy
 
   class AuthorResource < ApplicationResource
     attribute :first_name, :string
+    attribute :fname, :string # alias
     attribute :age, :integer
+    attribute :birthdays, :integer # alias
     attribute :float_age, :float
     attribute :decimal_age, :big_decimal
     attribute :active, :boolean

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -616,6 +616,172 @@ if ENV['APPRAISAL_INITIALIZED']
           end
         end
       end
+
+      context 'when aliasing the column' do
+        context 'when string' do
+          let(:filter) { { fname: value } }
+
+          describe 'eq' do
+            let(:value) { { eq: author2.first_name.upcase } }
+
+            it 'works' do
+              expect(ids).to eq([author2.id, author3.id])
+            end
+          end
+
+          describe 'not_eq' do
+            let(:value) { { not_eq: author2.first_name.upcase } }
+
+            it 'works' do
+              expect(ids).to eq([author1.id])
+            end
+          end
+
+          describe 'eql' do
+            let(:value) { { eql: author2.first_name } }
+
+            it 'works' do
+              expect(ids).to eq([author2.id])
+            end
+          end
+
+          describe 'not_eql' do
+            let(:value) { { not_eql: author2.first_name } }
+
+            it 'works' do
+              expect(ids).to eq([author1.id, author3.id])
+            end
+          end
+
+          describe 'prefix' do
+            let(:value) { { prefix: author2.first_name[0..3] } }
+
+            it 'works' do
+              expect(ids).to eq([author2.id, author3.id])
+            end
+          end
+
+          describe 'not_prefix' do
+            let(:value) { { not_prefix: author2.first_name[0..3] } }
+
+            it 'works' do
+              expect(ids).to eq([author1.id])
+            end
+          end
+
+          describe 'suffix' do
+            let(:value) { { suffix: 'rge' } }
+
+            it 'works' do
+              expect(ids).to eq([author2.id, author3.id])
+            end
+          end
+
+          describe 'not_suffix' do
+            let(:value) { { not_suffix: 'rge' } }
+
+            it 'works' do
+              expect(ids).to eq([author1.id])
+            end
+          end
+
+          describe 'match' do
+            let(:value) { { match: 'eor' } }
+
+            it 'works' do
+              expect(ids).to eq([author2.id, author3.id])
+            end
+          end
+
+          describe 'not match' do
+            let(:value) { { not_match: 'eor' } }
+
+            it 'works' do
+              expect(ids).to eq([author1.id])
+            end
+          end
+        end
+
+        context 'when numeric' do
+          let(:filter) { { birthdays: value } }
+
+          describe 'eq' do
+            let(:value) { { eq: author2.age } }
+
+            it 'works' do
+              expect(ids).to eq([author2.id])
+            end
+          end
+
+          describe 'not_eq' do
+            let(:value) { { not_eq: author2.age } }
+
+            it 'works' do
+              expect(ids).to eq([author1.id, author3.id])
+            end
+          end
+
+          describe 'gt' do
+            let(:value) { { gt: 70 } }
+
+            it 'works' do
+              expect(ids).to eq([author3.id])
+            end
+          end
+
+          describe 'gte' do
+            let(:value) { { gte: 70 } }
+
+            it 'works' do
+              expect(ids).to eq([author1.id, author3.id])
+            end
+          end
+
+          describe 'lt' do
+            let(:value) { { lt: 70 } }
+
+            it 'works' do
+              expect(ids).to eq([author2.id])
+            end
+          end
+
+          describe 'lte' do
+            let(:value) { { lte: 70 } }
+
+            it 'works' do
+              expect(ids).to eq([author1.id, author2.id])
+            end
+          end
+        end
+
+        context 'when datetime' do
+          let(:filter) { { created_at: value } }
+
+          describe 'eq' do
+            let(:value) { { eq: two_days_ago.iso8601 } }
+
+            it 'works' do
+              expect(ids).to eq([author2.id])
+            end
+          end
+
+          describe 'not_eq' do
+            let(:value) { { not_eq: two_days_ago.iso8601 } }
+
+            it 'works' do
+              expect(ids).to eq([author1.id, author3.id])
+            end
+          end
+
+          describe 'lte' do
+            let(:value) { { lte: one_day_ago.iso8601 } }
+
+            it 'works' do
+              expect(ids).to eq([author1.id, author2.id])
+            end
+          end
+        end
+      end
     end
 
     context 'when hitting #show' do
@@ -631,7 +797,9 @@ if ENV['APPRAISAL_INITIALIZED']
         expect(json['data']['id']).to eq(author1.id.to_s)
         expect(json['data']['attributes'].except('identifier')).to eq({
           'first_name' => 'Stephen',
+          'fname' => 'Stephen', # alias
           'age' => 70,
+          'birthdays' => 70, # alias
           'float_age' => 70.03,
           'decimal_age' => '70.033',
           'active' => true


### PR DESCRIPTION
Using `alias_attribute` in an ActiveRecord model would work for simpler
queries, but not for queries like `gt` where we dropped down to the
lower-level ARel DSL. This adds support for aliases to all
out-of-the-box filters.