### PR TITLE
Allow commas for singular filters

### DIFF
--- a/lib/graphiti/scoping/filter.rb
+++ b/lib/graphiti/scoping/filter.rb
@@ -157,6 +157,8 @@ module Graphiti
     # JSON of
     # {{{ "id": 1 }}} becomes { 'id' => 1 }
     def parse_string_value(filter, value)
+      return value if !!filter[:single]
+
       type = Graphiti::Types[filter[:type]]
       array_or_string = [:string, :array].include?(type[:canonical_name])
       if (arr = value.scan(/\[.*?\]/)).present? && array_or_string

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -126,6 +126,18 @@ RSpec.describe 'filtering' do
     end
   end
 
+  context 'when passed comma, but filter marked single: true' do
+    before do
+      resource.filter :first_name, single: true
+      employee2.update_attributes(first_name: 'foo,bar')
+      params[:filter] = { first_name: 'foo,bar' }
+    end
+
+    it 'does not parse as array' do
+      expect(records.map(&:id)).to eq([employee2.id])
+    end
+  end
+
   # Legacy Compat
   context 'when filter value is {{{escaped json string}}}' do
     before do
@@ -268,13 +280,6 @@ RSpec.describe 'filtering' do
           scope
         end
       end
-    end
-
-    it 'rejects multiples' do
-      params[:filter] = { first_name: { eq: 'William,Harold' } }
-      expect {
-        records
-      }.to raise_error(Graphiti::Errors::SingularFilter, /passed multiple values to filter :first_name/)
     end
 
     it 'allows singles' do


### PR DESCRIPTION
When a filter accepts multiple values, we use a comma to delimit them.
You can escape this by adding `{{ }}`:

`?filter[foo]={{bar,baz}}`

Would treat as string "bar,baz". However, singular filters should have
this behavior automatically, because we know they are never arrays.