### PR TITLE
Allow sideposting unwritable foreign keys

### DIFF
--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -94,7 +94,7 @@ The adapter #{@adapter.class} does not implement method '#{@method}', which was 
 
       def message
         <<-MSG
-#{@resource.class}: Tried to persist sideload #{@sideload.name.inspect} but marked writable: false
+#{@resource.class}: Tried to persist association #{@sideload.name.inspect} but marked writable: false
         MSG
       end
     end

--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -94,9 +94,9 @@ module Graphiti
       adapter.disassociate(parent, child, association_name, type)
     end
 
-    def persist_with_relationships(meta, attributes, relationships, caller_model = nil)
+    def persist_with_relationships(meta, attributes, relationships, caller_model = nil, foreign_key = nil)
       persistence = Graphiti::Util::Persistence \
-        .new(self, meta, attributes, relationships, caller_model)
+        .new(self, meta, attributes, relationships, caller_model, foreign_key)
       persistence.run
     end
 

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -149,6 +149,197 @@ if ENV["APPRAISAL_INITIALIZED"]
       end
     end
 
+    describe 'non-writable association' do
+      subject(:make_request) { do_update(payload) }
+
+      context 'when has_many' do
+        let(:klass) do
+          Class.new(EmployeeResource) do
+            self.validate_endpoints = false
+          end
+        end
+
+        let(:position_resource) do
+          Class.new(PositionResource) do
+            self.model = ::Position
+          end
+        end
+
+        let(:employee) { Employee.create!(first_name: 'Jane') }
+
+        let(:payload) do
+          {
+            data: {
+              type: 'employees',
+              id: employee.id.to_s,
+              relationships: {
+                positions: {
+                  data: [{
+                    :'temp-id' => 'abc123',
+                    type: 'positions',
+                    method: 'create'
+                  }]
+                }
+              }
+            },
+            included: [
+              {
+                :'temp-id' => 'abc123',
+                type: 'positions',
+                attributes: { title: 'foo' }
+              }
+            ]
+          }
+        end
+
+        before do
+          klass.has_many :positions, resource: position_resource, writable: false
+          allow(controller).to receive(:resource) { klass }
+        end
+
+        it 'raises error' do
+          expect {
+            make_request
+          }.to raise_error(Graphiti::Errors::UnwritableRelationship)
+        end
+      end
+
+      context 'when belongs_to' do
+        let(:klass) do
+          Class.new(EmployeeResource) do
+            self.validate_endpoints = false
+            belongs_to :classification, writable: false
+          end
+        end
+
+        let(:employee) { Employee.create!(first_name: 'Jane') }
+        let(:classification) { Classification.create!(description: 'foo') }
+
+        let(:payload) do
+          {
+            data: {
+              type: 'employees',
+              id: employee.id.to_s,
+              relationships: {
+                classification: {
+                  data: {
+                    id: classification.id.to_s,
+                    type: 'classifications'
+                  }
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          allow(controller).to receive(:resource) { klass }
+        end
+
+        it 'raises error' do
+          expect {
+            make_request
+          }.to raise_error(Graphiti::Errors::UnwritableRelationship)
+        end
+      end
+    end
+
+    describe 'non-writable foreign keys' do
+      subject(:make_request) { do_update(payload) }
+
+      context 'when belongs_to' do
+        let(:klass) do
+          Class.new(EmployeeResource) do
+            self.validate_endpoints = false
+            attribute :classification_id, :integer, writable: false
+          end
+        end
+
+        let(:employee) { Employee.create!(first_name: 'Jane') }
+        let(:classification) { Classification.create!(description: 'foo') }
+
+        let(:payload) do
+          {
+            data: {
+              type: 'employees',
+              id: employee.id.to_s,
+              relationships: {
+                classification: {
+                  data: {
+                    id: classification.id.to_s,
+                    type: 'classifications'
+                  }
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          allow(controller).to receive(:resource) { klass }
+        end
+
+        it 'does not require the FK to be a writable attribute' do
+          make_request
+          employee = Employee.last
+          expect(employee.classification_id).to eq(classification.id)
+        end
+      end
+
+      context 'when has_many' do
+        let(:klass) do
+          Class.new(EmployeeResource) do
+            self.validate_endpoints = false
+          end
+        end
+
+        let(:position_resource) do
+          Class.new(PositionResource) do
+            self.model = ::Position
+            attribute :employee_id, :integer, writable: false
+          end
+        end
+
+        let(:employee) { Employee.create!(first_name: 'Jane') }
+
+        let(:payload) do
+          {
+            data: {
+              type: 'employees',
+              id: employee.id.to_s,
+              relationships: {
+                positions: {
+                  data: [{
+                    :'temp-id' => 'abc123',
+                    type: 'positions',
+                    method: 'create'
+                  }]
+                }
+              }
+            },
+            included: [
+              {
+                :'temp-id' => 'abc123',
+                type: 'positions',
+                attributes: { title: 'foo' }
+              }
+            ]
+          }
+        end
+
+        before do
+          klass.has_many :positions, resource: position_resource
+          allow(controller).to receive(:resource) { klass }
+        end
+
+        it 'does not require the FK to be a writable attribute' do
+          make_request
+          employee = Employee.last
+          expect(employee.positions.map(&:title)).to eq(['foo'])
+        end
+      end
+    end
+
     describe 'has_one nested relationship' do
       context 'for new records' do
         let(:payload) do

--- a/spec/support/rails/employee_controller.rb
+++ b/spec/support/rails/employee_controller.rb
@@ -1,6 +1,10 @@
 EMPLOYEE_CONTROLLER_BLOCK = lambda do |*args|
+  def resource
+    EmployeeResource
+  end
+
   def create
-    employee = EmployeeResource.build(params)
+    employee = resource.build(params)
 
     if employee.save
       render jsonapi: employee
@@ -16,7 +20,7 @@ EMPLOYEE_CONTROLLER_BLOCK = lambda do |*args|
   end
 
   def update
-    employee = EmployeeResource.find(params)
+    employee = resource.find(params)
 
     if employee.update_attributes
       render jsonapi: employee
@@ -26,7 +30,7 @@ EMPLOYEE_CONTROLLER_BLOCK = lambda do |*args|
   end
 
   def destroy
-    employee = EmployeeResource.find(params)
+    employee = resource.find(params)
 
     if employee.destroy
       render json: { meta: {} }


### PR DESCRIPTION
We want to allow sideposting/associating entities, but this should not
require exposing the foreign key as a writable attribute. Instead, we
infer the foreign key from configuration instead of the request, and
make sure this doesn't go through the normal writability check. If the
developer wants to prohibit writing the association, they can do
`has_many :positions, writable: false`.