### PR TITLE
Prevent query when empty has_many

### DIFF
--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -190,6 +190,7 @@ module Graphiti
     def load(parents, query, graph_parent)
       params = load_params(parents, query)
       params_proc.call(params, parents) if params_proc
+      return [] if blank_query?(params)
       opts = load_options(parents, query)
       opts[:sideload] = self
       opts[:parent] = graph_parent
@@ -325,6 +326,15 @@ module Graphiti
     end
 
     private
+
+    def blank_query?(params)
+      if filter = params[:filter]
+        if filter.values == ['']
+          return true
+        end
+      end
+      false
+    end
 
     def validate_options!(opts)
       if opts[:remote]

--- a/lib/graphiti/sideload/belongs_to.rb
+++ b/lib/graphiti/sideload/belongs_to.rb
@@ -10,14 +10,6 @@ class Graphiti::Sideload::BelongsTo < Graphiti::Sideload
     end
   end
 
-  def load(parents, query, graph_parent)
-    if ids_for_parents(parents).empty?
-      []
-    else
-      super
-    end
-  end
-
   def base_filter(parents)
     parent_ids = ids_for_parents(parents)
     { primary_key => parent_ids.join(',') }


### PR DESCRIPTION
We were already preventing a sideload query for a belongs_to when the
foreign key was nil. This wasn't done for has_many because we expect you
to always have a *primary* key.

This isn't the case for nonstandard primary keys explicitly specified.
So, let's make sure we prevent a query in this case.

Similarly, both have issues where the pk/fk is nil or unused, but the
parameters are being customized manually. In this case, we want to make
sure we don't accidentally *prevent* the query.