### PR TITLE
Fix polymorphic many-to-many

### DIFF
--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -348,16 +348,6 @@ module Graphiti
       end
     end
 
-    def apply_belongs_to_many_filter
-      _self = self
-      fk_type = parent_resource_class.attributes[:id][:type]
-      resource_class.filter true_foreign_key, fk_type do
-        eq do |scope, value|
-          _self.belongs_to_many_filter(scope, value)
-        end
-      end
-    end
-
     def load_options(parents, query)
       {}.tap do |opts|
         opts[:default_paginate] = false

--- a/lib/graphiti/sideload/many_to_many.rb
+++ b/lib/graphiti/sideload/many_to_many.rb
@@ -23,6 +23,22 @@ class Graphiti::Sideload::ManyToMany < Graphiti::Sideload::HasMany
     false
   end
 
+  # Override in subclass
+  def polymorphic?
+    false
+  end
+
+  def apply_belongs_to_many_filter
+    _self = self
+    fk_type = parent_resource_class.attributes[:id][:type]
+    fk_type = :hash if polymorphic?
+    resource_class.filter true_foreign_key, fk_type do
+      eq do |scope, value|
+        _self.belongs_to_many_filter(scope, value)
+      end
+    end
+  end
+
   def assign_each(parent, children)
     children.select do |c|
       match = ->(ct) { ct.send(true_foreign_key) == parent.send(primary_key) }


### PR DESCRIPTION
The most common example of this is tags - many different models might
have a tag, and a tag can have many different models. So there's
typically a `taggings` table with `taggable_id` and `taggable_type`.

When sideloading/linking the tags, we were already taking into account
polymorphism. Because M2M is relational-DB-specific, we used
ActiveRecord to introspect the relationships and account for the
polymorphic join.

The problem occurs when you have multiple resources with `many_to_many
:tags` - the filter on `TagResource` would be `taggable_id`
(automatically applied under the hood). But when multiple resources have
this association, they'd continually overwrite the `taggable_id` filter.

The solution is to do this at runtime, not configuration time. When
linking this relationship, `taggable_id` shouldn't be an integer, but a
hash containing both the relevant `id` and the relevant `type`:

`?filter[taggable_id]={"id":1,"type":"authors"}`

For one, we solve the problem and prevent a collision on `taggable_id`.
But we also unlock the behavior of querying by multiple taggables at
once. This type of filter would be able to satisfy something like "give
me all tags for author 123 and book 456".

Notable, the `polymorphic_has_many` relationship queries by passing
*_id and *_type as separate filters. Perhaps this should change, but I
don't think it needs to - the use case is rare, doable with manual
filtering, and the current implementation is a bit more along the lines
of what a user expects.