### PR TITLE
Make better use of build matrix in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,30 @@ rvm:
 - 2.4
 - 2.5
 - 2.6
+gemfile:
+  - Gemfile
+  - gemfiles/rails_4.gemfile
+  - gemfiles/rails_5.gemfile
+env:
+  - COMMAND=standardrb --no-fix --format progress
+  - COMMAND=rspec
+  - COMMAND=rspec APPRAISAL_INITIALIZED=true
+matrix:
+  exclude:
+    - env: COMMAND=standardrb --no-fix --format progress
+      gemfile: gemfiles/rails_4.gemfile
+    - env: COMMAND=standardrb --no-fix --format progress
+      gemfile: gemfiles/rails_5.gemfile
+    - env: COMMAND=rspec APPRAISAL_INITIALIZED=true
+      gemfile: Gemfile
+    - env: COMMAND=rspec
+      gemfile: gemfiles/rails_4.gemfile
+    - env: COMMAND=rspec
+      gemfile: gemfiles/rails_5.gemfile
+
 script:
-  - bundle exec standardrb --no-fix
-  - bundle exec rspec
-  - bundle exec appraisal install
-  - bundle exec appraisal rails-5 rspec
-  - bundle exec appraisal rails-4 rspec
+  - bundle exec $COMMAND
+
 install: bundle install --retry=3 --jobs=3
 before_install:
 - gem install bundler -v '< 2'

--- a/graphiti.gemspec
+++ b/graphiti.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.3"
 
   # Pinning this version until backwards-incompatibility is addressed
-  spec.add_dependency "jsonapi-serializable", "~> 0.3.0"
+  spec.add_dependency "jsonapi-serializable", "= 0.3.0"
   spec.add_dependency "dry-types", "~> 0.13"
   spec.add_dependency "graphiti_errors", "~> 1.0.beta.1"
   spec.add_dependency "concurrent-ruby", "~> 1.0"


### PR DESCRIPTION
Previously we were running a number of test scripts in a given build
run. We used the travis `rvm` setting to at least run a separate build
for each ruby version, but didn't do any more than that.  This made it
harder for contributors not as familiar with our testing setup
to identify the specific errors that happened.  This was particularly
problematic with things like linting, where failures could easily get
buried at the top of the file.

This change will also make it easier to skip certain tests for certain
combinations.  For example, with rails 6, ruby 2.4 is no longer
supported, so this will allow us to add rails 6 to our appraisal suite
while easily skipping test runs for it in ruby 2.4.