### PR TITLE
Accomodate nested json hashes

### DIFF
--- a/lib/graphiti/scoping/filter.rb
+++ b/lib/graphiti/scoping/filter.rb
@@ -133,17 +133,8 @@ module Graphiti
       if value.is_a?(String)
         value = value.gsub("{{{", "{").gsub("}}}", "}")
 
-        # Accommodate array of hashes
-        if value.include?("},{")
-          value = value.split("},{").map { |v|
-            if v.starts_with?("{") && !v.ends_with?("}")
-              "#{v}}"
-            elsif v.ends_with?("}") && !v.starts_with?("{")
-              "{#{v}"
-            else
-              "{#{v}}"
-            end
-          }
+        if value.include?("},{") && !filter.values[0][:single]
+          value = Util::Hash.split_json(value)
         end
       end
 

--- a/lib/graphiti/util/hash.rb
+++ b/lib/graphiti/util/hash.rb
@@ -62,6 +62,24 @@ module Graphiti
           end
         end
       end
+
+      def self.split_json(string)
+        start, opens, closes, index = 0, 0, 0, -1
+        [].tap do |jsons|
+          string[0..string.length].each_char do |char|
+            index += 1
+            opens += 1 if char == "{"
+            if char == "}"
+              closes += 1
+
+              if opens == closes
+                jsons << string.slice(start..index)
+                start = index + 2
+              end
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We could parse simple hashes, and arrays of simple hashes. But a complex
hash, that contains nested hashes within itself, would be incorrectly
parsed - we would think it was an array when it really wasn't. This was
due to a naive implementation splitting on `},{`.

This implementation is more intelligent, only splitting when a full
snippet of JSON is encapsulated. We also avoid attempting to split
altogether when marked `single: true`.