### PR TITLE
Check canonical name for hash parsing

### DIFF
--- a/lib/graphiti/scoping/filter.rb
+++ b/lib/graphiti/scoping/filter.rb
@@ -48,7 +48,9 @@ module Graphiti
         value, operator = normalize_param(filter, param_value)
         operator = operator.to_s.gsub("!", "not_").to_sym
         validate_operator(filter, operator)
-        unless filter.values[0][:type] == :hash || !value.is_a?(String)
+
+        type = Types[filter.values[0][:type]]
+        unless type[:canonical_name] == :hash || !value.is_a?(String)
           value = parse_string_value(filter.values[0], value)
         end
         validate_singular(resource, filter, value)
@@ -80,7 +82,7 @@ module Graphiti
       value = param_value.values.first
       operator = param_value.keys.first
 
-      if filter.values[0][:type] == :hash
+      if Types[filter.values[0][:type]][:canonical_name] == :hash
         value, operator = \
           parse_hash_value(filter, param_value, value, operator)
       else

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -113,6 +113,36 @@ RSpec.describe "filtering" do
     end
   end
 
+  context "when filter is custom hash schema" do
+    before do
+      foo = Dry::Types["hash"].schema(foo: Dry::Types["strict.string"])
+      Graphiti::Types[:custom] = {
+        params: foo,
+        read: foo,
+        write: foo,
+        kind: "record",
+        canonical_name: :hash,
+        description: "Foo",
+      }
+      resource.filter :blah, :custom do
+        eq do |scope, hash|
+          scope[:conditions][:id] = 2 if hash[0][:foo] == "bar"
+          scope
+        end
+      end
+
+      params[:filter] = {blah: {foo: "bar"}}
+    end
+
+    after do
+      Graphiti::Types.map.delete(:custom)
+    end
+
+    it "works" do
+      expect(records.map(&:id)).to eq([employee2.id])
+    end
+  end
+
   context "when filter is a {{string}} with a comma" do
     before do
       params[:filter] = {first_name: "{{foo,bar}}"}


### PR DESCRIPTION
When registering a custom type that is a hash schema, we weren't
realizing it should follow the same hash parsing rules (the net effect
is you just had to put `{eq: ...}` in explicitly). This not checks the
canonical name instead of the type to identify hashes.