### PR TITLE
Render #resolve meta when available

### DIFF
--- a/lib/graphiti/renderer.rb
+++ b/lib/graphiti/renderer.rb
@@ -45,7 +45,7 @@ module Graphiti
         options[:expose][:proxy] = proxy
         options[:include] = proxy.include_hash
         options[:links] = proxy.pagination.links if proxy.pagination.links?
-        options[:meta] ||= {}
+        options[:meta] ||= proxy.meta
         options[:meta][:stats] = proxy.stats unless proxy.stats.empty?
         options[:meta][:debug] = Debugger.to_a if debug_json?
 

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -33,7 +33,6 @@ module Graphiti
     end
 
     def jsonapi_render_options(opts = {})
-      opts[:meta]   ||= {}
       opts[:expose] ||= {}
       opts[:expose][:context] = Graphiti.context[:object]
       opts
@@ -63,6 +62,10 @@ module Graphiti
       end
     end
     alias to_a data
+
+    def meta
+      @meta ||= data.respond_to?(:meta) ? data.meta : {}
+    end
 
     def each(&blk)
       to_a.each(&blk)

--- a/spec/rendering_spec.rb
+++ b/spec/rendering_spec.rb
@@ -101,6 +101,30 @@ RSpec.describe "serialization" do
       expect(position["department"]).to be_nil
     end
 
+    class RenderResults < SimpleDelegator
+      attr_accessor :meta
+
+      def initialize(array, meta:)
+        super(array)
+        @meta = meta
+      end
+    end
+
+    context 'when resolved data has meta' do
+      before do
+        resource.class_eval do
+          def resolve(scope)
+            RenderResults.new(super, meta: { foo: 'bar' })
+          end
+        end
+      end
+
+      it 'is returned in the response' do
+        json = JSON.parse(proxy.to_jsonapi)
+        expect(json['meta']).to eq({ 'foo' => 'bar' })
+      end
+    end
+
     context "when sideloading" do
       it "works" do
         expect(json[0]["positions"]).to eq([

--- a/spec/stats_spec.rb
+++ b/spec/stats_spec.rb
@@ -156,11 +156,11 @@ RSpec.describe "stats" do
         before do
           resource.class_eval do
             stat :age do
-              second { |_, _, _, data| data.meta }
+              second { |_, _, _, data| data.meta[:stats][:age] }
             end
 
             def resolve(scope)
-              Results.new(super, meta: "from meta!")
+              Results.new(super, meta: { stats: { age: "from meta!" } })
             end
           end
         end


### PR DESCRIPTION
If you wrap the `#resolve` results in a proxy that responds to `meta`,
let's automatically render that for you.