### PR TITLE
Allow passing @object to guard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,17 @@ matrix:
       gemfile: gemfiles/rails_6.gemfile
     - gemfile: gemfiles/rails_6.gemfile
       rvm: 2.4
+    - gemfile: gemfiles/rails_4.gemfile
+      rvm: 2.5
+    - gemfile: gemfiles/rails_4.gemfile
+      rvm: 2.6
 
 script:
   - bundle exec $COMMAND
 
 install: bundle install --retry=3 --jobs=3
 before_install:
-- gem install bundler -v '< 2'
+- gem install bundler -v '1.17.3'
 deploy:
   provider: rubygems
   api_key:

--- a/gemfiles/.bundle/config
+++ b/gemfiles/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_RETRY: "1"

--- a/lib/graphiti/util/serializer_attributes.rb
+++ b/lib/graphiti/util/serializer_attributes.rb
@@ -53,9 +53,17 @@ module Graphiti
       end
 
       def guard
-        guard_method = @attr[:readable]
+        method_name = @attr[:readable]
         instance = @resource.new
-        -> { instance.instance_eval(&guard_method) }
+
+        -> {
+          method = instance.method(method_name)
+          if method.arity.zero?
+            instance.instance_eval(&method_name)
+          else
+            instance.instance_exec(@object, &method)
+          end
+        }
       end
 
       def guard?

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -772,6 +772,21 @@ RSpec.describe "serialization" do
           expect(json["data"][0]["attributes"]).to_not have_key("foo")
         end
       end
+
+      context 'and the guard accepts an argument' do
+        before do
+          resource.class_eval do
+            def admin?(object)
+              object.is_a?(PORO::Employee)
+            end
+          end
+        end
+
+        it 'is passed the model instance as argument' do
+          render
+          expect(json["data"][0]["attributes"]["foo"]).to eq("bar")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
When guarding during serialization, `@object` will now be passed as an
argument when the corresponding method accepts an argument:

```ruby
attribute :foo, :string, readable: :allowed?

def allowed?(model_instance)
  model_instance.private == true
end
```