### PR TITLE
Wrap common sideload errors

### DIFF
--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -10,7 +10,7 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           The adapter #{@adapter.class} does not implement method '#{@method}', which was requested for attribute '#{@attribute}'. Add this method to your adapter to support this filter operator.
         MSG
       end
@@ -24,7 +24,7 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           #{@parent_resource_class} sideload :#{@name} - #{@message}
         MSG
       end
@@ -53,7 +53,7 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           #{@resource_class}: Tried to pass block to .#{@method_name}, which only accepts a method name.
         MSG
       end
@@ -65,7 +65,7 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           #{@resource_class}: Tried to perform write operation. Writes are not supported for remote resources - hit the endpoint directly.
         MSG
       end
@@ -80,7 +80,7 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           #{@resource.class}: Tried to filter #{@filter_name.inspect} on operator #{@operator.inspect}, but not supported! Supported operators are #{@supported}.
         MSG
       end
@@ -93,7 +93,7 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           #{@resource.class}: Tried to persist association #{@sideload.name.inspect} but marked writable: false
         MSG
       end
@@ -106,7 +106,7 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           #{@sideload.parent_resource.class.name}: tried to sideload #{@sideload.name.inspect}, but more than one #{@sideload.parent_resource.model.name} was passed!
 
           This is because you marked the sideload #{@sideload.name.inspect} with single: true
@@ -127,7 +127,7 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           #{@resource.class.name}: tried to sort on attribute #{@attribute.inspect}, but passed #{@direction.inspect} when only #{@allowlist.inspect} is supported.
         MSG
       end
@@ -140,7 +140,7 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           #{@resource_class.name}: called .on_extra_attribute #{@name.inspect}, but extra attribute #{@name.inspect} does not exist!
         MSG
       end
@@ -156,7 +156,7 @@ module Graphiti
       def message
         allow = @filter.values[0][:allow]
         deny = @filter.values[0][:deny]
-        msg = <<~MSG
+        msg = <<-MSG
           #{@resource.class.name}: tried to filter on #{@filter.keys[0].inspect}, but passed invalid value #{@value.inspect}.
         MSG
         msg << "\nAllowlist: #{allow.inspect}" if allow
@@ -173,7 +173,7 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           #{@resource_class.name}: Cannot link to sideload #{@sideload.name.inspect}!
 
           Make sure the endpoint "#{@sideload.resource.endpoint[:full_path]}" exists with action #{@action.inspect}, or customize the endpoint for #{@sideload.resource.class.name}.
@@ -191,7 +191,7 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           #{@resource.class.name}: passed multiple values to filter #{@filter.keys[0].inspect}, which was marked single: true.
 
           Value was: #{@value.inspect}
@@ -206,12 +206,80 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           #{@resource_class.name}: Tried to link sideload #{@sideload.name.inspect}, but cannot generate links!
 
           Graphiti.config.context_for_endpoint must be set to enable link generation:
 
           Graphiti.config.context_for_endpoint = ->(path, action) { ... }
+        MSG
+      end
+    end
+
+    class SideloadParamsError < Base
+      def initialize(resource_class, sideload_name)
+        @resource_class = resource_class
+        @sideload_name = sideload_name
+      end
+
+      def message
+        <<-MSG
+          #{@resource_class.name}: error occurred while sideloading "#{@sideload_name}"!
+
+          The error was raised while attempting to build query parameters for the associated Resource.
+          Read more about sideload scoping here: www.graphiti.dev/guides/concepts/resources#customizing-scope
+
+          A good way to debug is to put a debugger within the 'params' block.
+
+          Here's the original, underlying error:
+
+          #{cause.class.name}: #{cause}
+          #{cause.backtrace.join("\n")}
+        MSG
+      end
+    end
+
+    class SideloadQueryBuildingError < Base
+      def initialize(resource_class, sideload_name)
+        @resource_class = resource_class
+        @sideload_name = sideload_name
+      end
+
+      def message
+        <<-MSG
+          #{@resource_class.name}: error occurred while sideloading "#{@sideload_name}"!
+
+          The error was raised while attempting to build the scope for the associated Resource.
+
+          Read more about sideload scoping here: www.graphiti.dev/guides/concepts/resources#customizing-scope
+
+          Here's the original, underlying error:
+
+          #{cause.class.name}: #{cause.message}
+          #{cause.backtrace.join("\n")}
+        MSG
+      end
+    end
+
+    class SideloadAssignError < Base
+      def initialize(resource_class, sideload_name)
+        @resource_class = resource_class
+        @sideload_name = sideload_name
+      end
+
+      def message
+        <<-MSG
+          #{@resource_class.name}: error occurred while sideloading "#{@sideload_name}"!
+
+          The error was raised while attempting to assign relevant model instances. Read
+          more about sideload assignment here: www.graphiti.dev/guides/concepts/resources#customizing-assignment
+
+          A good way to debug is to put a debugger within the 'assign' block.
+
+          Here's the original, underlying error:
+
+          #{cause.class.name}: #{cause.message}
+          #{cause.backtrace.join("\n")}
         MSG
       end
     end
@@ -282,7 +350,7 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           #{@resource.class.name}: passed filter with value #{@value.inspect}, and failed attempting to parse as JSON array.
         MSG
       end
@@ -296,7 +364,7 @@ module Graphiti
       end
 
       def message
-        <<~MSG
+        <<-MSG
           #{@resource_class.name} cannot be called directly from endpoint #{@path}##{@action}!
 
           Either set a primary endpoint for this resource:

--- a/spec/error_trapping_spec.rb
+++ b/spec/error_trapping_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+RSpec.describe "trapping errors" do
+  let(:klass) do
+    Class.new(PORO::ApplicationResource) do
+      def self.name
+        "PORO::EmployeeResource"
+      end
+    end
+  end
+
+  let(:position_resource) do
+    Class.new(PORO::ApplicationResource) do
+      def self.name
+        "PORO::PositionResource"
+      end
+    end
+  end
+
+  let!(:employee) { PORO::Employee.create }
+  let!(:position) { PORO::Position.create(employee_id: employee.id) }
+
+  describe "when error happens during sideload parameter building" do
+    before do
+      klass.has_many :positions, resource: position_resource do
+        params do
+          raise "asdf"
+        end
+      end
+    end
+
+    it "traps correctly" do
+      expect {
+        klass.all(include: "positions").data
+      }.to raise_error(Graphiti::Errors::SideloadParamsError, /PORO::EmployeeResource: error occurred while sideloading "positions"!/)
+    end
+  end
+
+  describe "when error happens during sideload query building" do
+    before do
+      klass.has_many :positions, resource: position_resource
+    end
+
+    it "traps correctly" do
+      expect {
+        klass.all(include: "positions").data
+      }.to raise_error(Graphiti::Errors::SideloadQueryBuildingError, /PORO::EmployeeResource: error occurred while sideloading "positions"!/)
+    end
+  end
+
+  describe "when error happens during sideload assignment" do
+    before do
+      position_resource.filter :employee_id, :integer
+      klass.has_many :positions, resource: position_resource do
+        assign do
+          raise "asd"
+        end
+      end
+    end
+
+    it "traps correctly" do
+      expect {
+        klass.all(include: "positions").data
+      }.to raise_error(Graphiti::Errors::SideloadAssignError, /PORO::EmployeeResource: error occurred while sideloading "positions"!/)
+    end
+  end
+end

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -871,7 +871,11 @@ if ENV["APPRAISAL_INITIALIZED"]
         context "and > 1 parents" do
           it "raises error" do
             expect {
-              request
+              begin
+                request
+              rescue => e
+                raise e.cause
+              end
             }.to raise_error(Graphiti::Errors::UnsupportedPagination)
           end
         end
@@ -1102,7 +1106,11 @@ if ENV["APPRAISAL_INITIALIZED"]
 
         it "derives the foreign key directly" do
           expect {
-            do_index({include: "hobbies"})
+            begin
+              do_index({include: "hobbies"})
+            rescue => e
+              raise e.cause
+            end
           }.to raise_error(Graphiti::Errors::AttributeError, /author_id/)
         end
       end


### PR DESCRIPTION
If you already understand how Graphiti works, it's pretty easy to track
down why a sideload error is happening. But if that's not the case, you feel
kinda stuck with a random error. A good example is a nonstandard foreign key,
or forgetting to add an `attr_accessor` to your model.

This commit now wraps sideload errors, so we can provide context around
the place in the lifecycle the error is occurring:

* Parameter building
* Query Building
* Assignment

We'll still contain the original error message and backtrace in the
wrapped error message. This is also compatibile with Error#cause https://www.honeybadger.io/blog/nested-errors-in-ruby-with-exception-cause/

These errors usually only occur during development. Let's give
developers better information.