### PR TITLE
Update DryTypes to 0.15

### DIFF
--- a/graphiti.gemspec
+++ b/graphiti.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.3"
 
   spec.add_dependency "jsonapi-serializable", "~> 0.3.0"
-  spec.add_dependency "dry-types", "~> 0.13"
+  spec.add_dependency "dry-types", "~> 0.15"
   spec.add_dependency "graphiti_errors", "~> 1.0.beta.1"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "activesupport", [">= 4.1", "< 6"]

--- a/lib/graphiti/types.rb
+++ b/lib/graphiti/types.rb
@@ -1,7 +1,7 @@
 module Graphiti
   class Types
     def self.create(primitive, &blk)
-      definition = Dry::Types::Definition.new(primitive)
+      definition = Dry::Types::Nominal.new(primitive)
       definition.constructor(&blk)
     end
 

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -1072,7 +1072,7 @@ RSpec.describe "filtering" do
 
     context "when custom type" do
       before do
-        type = Dry::Types::Definition
+        type = Dry::Types::Nominal
           .new(nil)
           .constructor { |input|
             "custom!"

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -2102,7 +2102,7 @@ RSpec.describe "persistence" do
 
     context "when custom type" do
       before do
-        type = Dry::Types::Definition
+        type = Dry::Types::Nominal
           .new(nil)
           .constructor { |input|
             "custom!"

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "serialization" do
 
     context "when id is custom type" do
       before do
-        type = Dry::Types::Definition.new(String).constructor { |input|
+        type = Dry::Types::Nominal.new(String).constructor { |input|
           "custom!"
         }
         Graphiti::Types[:custom] = {
@@ -555,7 +555,7 @@ RSpec.describe "serialization" do
 
       context "when custom type" do
         before do
-          type = Dry::Types::Definition
+          type = Dry::Types::Nominal
             .new(nil)
             .constructor { |input|
               "custom!"


### PR DESCRIPTION
Change Dry::Types::Definition to Nominal to satisfy deprecation
warning. The deprecation was added as part of https://github.com/dry-rb/dry-types/blob/master/CHANGELOG.md#0150-2019-03-22