### PR TITLE
Don't link unexpected polymorphic type

### DIFF
--- a/lib/graphiti/util/link.rb
+++ b/lib/graphiti/util/link.rb
@@ -11,6 +11,7 @@ module Graphiti
             @sideload = @sideload.children.values.find { |c|
               c.group_name == type.to_sym
             }
+            @polymorphic_sideload_not_found = true unless @sideload
           else
             @linkable = false
           end
@@ -26,6 +27,8 @@ module Graphiti
       private
 
       def linkable?
+        return false if @polymorphic_sideload_not_found
+
         if @sideload.type == :belongs_to
           !@model.send(@sideload.foreign_key).nil?
         else

--- a/spec/sideloading_spec.rb
+++ b/spec/sideloading_spec.rb
@@ -419,6 +419,31 @@ RSpec.describe "sideloading" do
       end
     end
 
+    context 'when linking unknown type' do
+      before do
+        Graphiti::Resource.autolink = true
+        params.delete(:include)
+        params[:links] = true
+        resource.polymorphic_belongs_to :credit_card do
+          group_by(:credit_card_type) do
+            on(:Visa)
+            on(:Mastercard)
+          end
+        end
+      end
+
+      after do
+        Graphiti::Resource.autolink = false
+      end
+
+      it 'does not blow up' do
+        render
+        expect(d[0].link(:credit_card, :related)).to be_present
+        expect(d[1].link(:credit_card, :related)).to be_present
+        expect(d[2].link(:credit_card, :related)).to be_nil
+      end
+    end
+
     context "with except option specified" do
       before do
         resource.polymorphic_belongs_to :credit_card do


### PR DESCRIPTION
If you try to sideload a `polymorphic_belongs_to`, and we encounter a
type not registered (and not in only/except), we'll raise a helpful
error. But if you aren't sideloading, and just generating a Link, and we
encounter an unknown type, you get a really confusing error.

This instead just omits the Link. I don't think we should blow up in
this case because the client isn't actually requesting anything here -
maybe the client only sideloads on data where the types are known.