### PR TITLE
Add "enum" type

### DIFF
--- a/lib/graphiti/adapters/abstract.rb
+++ b/lib/graphiti/adapters/abstract.rb
@@ -36,6 +36,7 @@ module Graphiti
             :not_match,
           ],
           uuid: [:eq, :not_eq],
+          enum: [:eq, :not_eq],
           integer_id: numerical_operators,
           integer: numerical_operators,
           big_decimal: numerical_operators,

--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -25,6 +25,7 @@ module Graphiti
       alias filter_date_eq filter_eq
       alias filter_boolean_eq filter_eq
       alias filter_uuid_eq filter_eq
+      alias filter_enum_eq filter_eq
 
       def filter_not_eq(scope, attribute, value)
         scope.where.not(attribute => value)
@@ -35,6 +36,7 @@ module Graphiti
       alias filter_date_not_eq filter_not_eq
       alias filter_boolean_not_eq filter_not_eq
       alias filter_uuid_not_eq filter_not_eq
+      alias filter_enum_not_eq filter_not_eq
 
       def filter_string_eq(scope, attribute, value, is_not: false)
         column = column_for(scope, attribute)

--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -165,6 +165,29 @@ module Graphiti
       end
     end
 
+    class MissingEnumAllowList < Base
+      def initialize(resource_class, filter_name)
+        @resource_class = resource_class
+        @filter_name = filter_name
+      end
+
+      def message
+        <<-MSG
+          #{@resource_class.name} You declared an attribute or filter of type "enum" without providing a list of permitted values, which is required.
+
+          When declaring an attribute:
+
+          attribute :status, :string_enum, allow: ['published', 'draft']
+
+          When declaring a filter:
+
+          filter :status, :string_enum, allow: ['published', 'draft'] do
+            # ...
+          end
+        MSG
+      end
+    end
+
     class InvalidLink < Base
       def initialize(resource_class, sideload, action)
         @resource_class = resource_class

--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -166,22 +166,23 @@ module Graphiti
     end
 
     class MissingEnumAllowList < Base
-      def initialize(resource_class, filter_name)
+      def initialize(resource_class, filter_name, enum_type)
         @resource_class = resource_class
         @filter_name = filter_name
+        @enum_type = enum_type
       end
 
       def message
         <<-MSG
-          #{@resource_class.name} You declared an attribute or filter of type "enum" without providing a list of permitted values, which is required.
+          #{@resource_class.name} You declared an attribute or filter of type "#{@enum_type}" without providing a list of permitted values, which is required.
 
           When declaring an attribute:
 
-          attribute :status, :string_enum, allow: ['published', 'draft']
+          attribute :status, :#{@enum_type}, allow: ['published', 'draft']
 
           When declaring a filter:
 
-          filter :status, :string_enum, allow: ['published', 'draft'] do
+          filter :status, :#{@enum_type}, allow: ['published', 'draft'] do
             # ...
           end
         MSG

--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -12,8 +12,13 @@ module Graphiti
             aliases = [name, opts[:aliases]].flatten.compact
             operators = FilterOperators.build(self, att[:type], opts, &blk)
 
-            if Graphiti::Types[att[:type]][:canonical_name] == :boolean
+            case Graphiti::Types[att[:type]][:canonical_name]
+            when :boolean
               opts[:single] = true
+            when :enum
+              if opts[:allow].blank?
+                raise Errors::MissingEnumAllowList.new(self, name)
+              end
             end
 
             required = att[:filterable] == :required || !!opts[:required]
@@ -29,7 +34,7 @@ module Graphiti
               operators: operators.to_hash,
             }
           elsif (type = args[0])
-            attribute name, type, only: [:filterable]
+            attribute name, type, only: [:filterable], allow: opts[:allow]
             filter(name, opts, &blk)
           else
             raise Errors::ImplicitFilterTypeMissing.new(self, name)
@@ -100,8 +105,13 @@ module Graphiti
           options[:proc] = blk
           config[:attributes][name] = options
           apply_attributes_to_serializer
-          options[:filterable] ? filter(name) : config[:filters].delete(name)
           options[:sortable] ? sort(name) : config[:sorts].delete(name)
+
+          if options[:filterable]
+            filter(name, allow: options[:allow])
+          else
+            config[:filters].delete(name)
+          end
         end
 
         def extra_attribute(name, type, options = {}, &blk)

--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -17,7 +17,7 @@ module Graphiti
               opts[:single] = true
             when :enum
               if opts[:allow].blank?
-                raise Errors::MissingEnumAllowList.new(self, name)
+                raise Errors::MissingEnumAllowList.new(self, name, att[:type])
               end
             end
 

--- a/lib/graphiti/types.rb
+++ b/lib/graphiti/types.rb
@@ -109,6 +109,14 @@ module Graphiti
             kind: "scalar",
             description: "String enum type. Like a normal string, but only eq/!eq and case-sensitive. Limited to only the allowed values.",
           },
+          integer_enum: {
+            canonical_name: :enum,
+            params: Dry::Types["coercible.integer"],
+            read: Dry::Types["coercible.integer"],
+            write: Dry::Types["coercible.integer"],
+            kind: "scalar",
+            description: "Integer enum type. Like a normal integer, but only eq/!eq filters. Limited to only the allowed values.",
+          },
           string: {
             params: Dry::Types["coercible.string"],
             read: Dry::Types["coercible.string"],

--- a/lib/graphiti/types.rb
+++ b/lib/graphiti/types.rb
@@ -101,6 +101,14 @@ module Graphiti
             kind: "scalar",
             description: "Base Type. Like a normal string, but by default only eq/!eq and case-sensitive.",
           },
+          string_enum: {
+            canonical_name: :enum,
+            params: Dry::Types["coercible.string"],
+            read: Dry::Types["coercible.string"],
+            write: Dry::Types["coercible.string"],
+            kind: "scalar",
+            description: "String enum type. Like a normal string, but only eq/!eq and case-sensitive. Limited to only the allowed values.",
+          },
           string: {
             params: Dry::Types["coercible.string"],
             read: Dry::Types["coercible.string"],

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -378,32 +378,32 @@ RSpec.describe "filtering" do
   context "when filtering on an enum field" do
     context "when allowed values are provided" do
       before do
-        resource.filter :enum_first_name, :string_enum, allow: ["William"] do
+        resource.filter :enum_age, :integer_enum, allow: [1, 3, 5] do
           eq do |scope, value|
-            scope[:conditions][:first_name] = value
+            scope[:conditions][:age] = value
             scope
           end
         end
       end
 
       it "rejects values not in the allowlist" do
-        params[:filter] = {enum_first_name: {eq: "Harold"}}
+        params[:filter] = {enum_age: {eq: 2}}
         expect {
           records
-        }.to raise_error(Graphiti::Errors::InvalidFilterValue, /Allowlist: \[\"William\"\]/)
+        }.to raise_error(Graphiti::Errors::InvalidFilterValue, /Allowlist: \[1, 3, 5]/)
       end
     end
 
     context "when allow list is omitted" do
       it "raises an error at load time" do
         expect {
-          resource.filter :enum_first_name, :string_enum do
+          resource.filter :enum_age, :integer_enum do
             eq do |scope, value|
-              scope[:conditions][:first_name] = value
+              scope[:conditions][:age] = value
               scope
             end
           end
-        }.to raise_error(Graphiti::Errors::MissingEnumAllowList)
+        }.to raise_error(Graphiti::Errors::MissingEnumAllowList, /integer_enum/)
       end
     end
   end

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -375,6 +375,39 @@ RSpec.describe "filtering" do
     end
   end
 
+  context "when filtering on an enum field" do
+    context "when allowed values are provided" do
+      before do
+        resource.filter :enum_first_name, :string_enum, allow: ["William"] do
+          eq do |scope, value|
+            scope[:conditions][:first_name] = value
+            scope
+          end
+        end
+      end
+
+      it "rejects values not in the allowlist" do
+        params[:filter] = {enum_first_name: {eq: "Harold"}}
+        expect {
+          records
+        }.to raise_error(Graphiti::Errors::InvalidFilterValue, /Allowlist: \[\"William\"\]/)
+      end
+    end
+
+    context "when allow list is omitted" do
+      it "raises an error at load time" do
+        expect {
+          resource.filter :enum_first_name, :string_enum do
+            eq do |scope, value|
+              scope[:conditions][:first_name] = value
+              scope
+            end
+          end
+        }.to raise_error(Graphiti::Errors::MissingEnumAllowList)
+      end
+    end
+  end
+
   context "when only allowing single values" do
     before do
       resource.filter :first_name, :string, single: true do

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -395,15 +395,30 @@ RSpec.describe "filtering" do
     end
 
     context "when allow list is omitted" do
-      it "raises an error at load time" do
-        expect {
-          resource.filter :enum_age, :integer_enum do
-            eq do |scope, value|
-              scope[:conditions][:age] = value
-              scope
+      context 'when using a string_enum field' do
+        it "raises an error at load time" do
+          expect {
+            resource.filter :enum_first_name, :string_enum do
+              eq do |scope, value|
+                scope[:conditions][:first_name] = value
+                scope
+              end
             end
-          end
-        }.to raise_error(Graphiti::Errors::MissingEnumAllowList, /integer_enum/)
+          }.to raise_error(Graphiti::Errors::MissingEnumAllowList, /string_enum/)
+        end
+      end
+
+      context 'when using an integer_enum field' do
+        it "raises an error at load time" do
+          expect {
+            resource.filter :enum_age, :integer_enum do
+              eq do |scope, value|
+                scope[:conditions][:age] = value
+                scope
+              end
+            end
+          }.to raise_error(Graphiti::Errors::MissingEnumAllowList, /integer_enum/)
+        end
       end
     end
   end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -671,6 +671,23 @@ RSpec.describe Graphiti::Resource do
           }.to(change { klass.filters[:foo] })
         end
       end
+
+      context 'when the attribute is of type "enum"' do
+        context "and an allow list is passed in" do
+          it "correctly adds to the filter allowlist" do
+            klass.attribute :foo, :string_enum, allow: ["bar", "baz"]
+            expect(klass.filters[:foo][:allow]).to eq ["bar", "baz"]
+          end
+        end
+
+        context "and an allow list omitted" do
+          it "raises a helpful error" do
+            expect {
+              klass.attribute :foo, :string_enum
+            }.to raise_error(Graphiti::Errors::MissingEnumAllowList)
+          end
+        end
+      end
     end
 
     context "when not filterable" do

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -684,7 +684,7 @@ RSpec.describe Graphiti::Resource do
           it "raises a helpful error" do
             expect {
               klass.attribute :foo, :string_enum
-            }.to raise_error(Graphiti::Errors::MissingEnumAllowList)
+            }.to raise_error(Graphiti::Errors::MissingEnumAllowList, /string_enum/)
           end
         end
       end

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -89,6 +89,10 @@ RSpec.describe Graphiti::Schema do
             description: "String enum type. Like a normal string, but only eq/!eq and case-sensitive. Limited to only the allowed values.",
             kind: "scalar",
           },
+          integer_enum: {
+            description: "Integer enum type. Like a normal integer, but only eq/!eq filters. Limited to only the allowed values.",
+            kind: "scalar"
+          },
           integer: {
             kind: "scalar",
             description: "Base Type.",
@@ -134,6 +138,10 @@ RSpec.describe Graphiti::Schema do
             kind: "array",
           },
           array_of_string_enums: {
+            description: "Base Type.",
+            kind: "array",
+          },
+          array_of_integer_enums: {
             description: "Base Type.",
             kind: "array",
           },

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -85,6 +85,10 @@ RSpec.describe Graphiti::Schema do
             description: "Base Type. Like a normal string, but by default only eq/!eq and case-sensitive.",
             kind: "scalar",
           },
+          string_enum: {
+            description: "String enum type. Like a normal string, but only eq/!eq and case-sensitive. Limited to only the allowed values.",
+            kind: "scalar",
+          },
           integer: {
             kind: "scalar",
             description: "Base Type.",
@@ -126,6 +130,10 @@ RSpec.describe Graphiti::Schema do
             description: "Base Type.",
           },
           array_of_uuids: {
+            description: "Base Type.",
+            kind: "array",
+          },
+          array_of_string_enums: {
             description: "Base Type.",
             kind: "array",
           },
@@ -433,6 +441,19 @@ RSpec.describe Graphiti::Schema do
 
       it "is marked as such" do
         expect(schema[:resources][0][:filters][:first_name][:allow])
+          .to eq(["foo"])
+      end
+    end
+
+    context "when the attribute is a string enum" do
+      before do
+        employee_resource.class_eval do
+          attribute :enum_first_name, :string_enum, allow: [:foo]
+        end
+      end
+
+      it "reflects the values in the filters" do
+        expect(schema[:resources][0][:filters][:enum_first_name][:allow])
           .to eq(["foo"])
       end
     end

--- a/spec/sideloading_spec.rb
+++ b/spec/sideloading_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe "sideloading" do
       end
     end
 
-    context 'when linking unknown type' do
+    context "when linking unknown type" do
       before do
         Graphiti::Resource.autolink = true
         params.delete(:include)
@@ -436,7 +436,7 @@ RSpec.describe "sideloading" do
         Graphiti::Resource.autolink = false
       end
 
-      it 'does not blow up' do
+      it "does not blow up" do
         render
         expect(d[0].link(:credit_card, :related)).to be_present
         expect(d[1].link(:credit_card, :related)).to be_present


### PR DESCRIPTION
When are dealing with an enum type, we don't want to accept anything not
in the list of values, nor do we want to niavely run them through the
string casting logic that exists in things like the activerecord
case-insensitive string filters.  When using the new `enum` type in
either your filters or your attributes, you will get an error if you
don't provide an `allow` option:

```ruby
# raises Graphiti::Errors::MissingEnumAllowList
attribute :status, :enum

# OK
attribute :status, :enum, allow: ['published', 'draft']
```

Note that this currently only works for filtering.  Eventually, I would
like to add the ability to prevent anything except for the allowlist
from being written automatically as well, but since users should be
handling this at their model or database layer anyway, I'm not worried
about it for this first version.