### PR TITLE
Improve remote resource behavior

### DIFF
--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -38,6 +38,12 @@ module Graphiti
         def remote=(val)
           super
           include ::Graphiti::Resource::Remote
+          self.endpoint = {
+            path: val,
+            full_path: val,
+            url: val,
+            actions: [:index, :show],
+          }
         end
 
         def model

--- a/lib/graphiti/resource/remote.rb
+++ b/lib/graphiti/resource/remote.rb
@@ -18,8 +18,12 @@ module Graphiti
         end
       end
 
-      def save(*args)
-        raise Errors::RemoteWrite.new(self.class)
+      def save(model, meta)
+        if meta[:attributes] == {} && meta[:method] == :update
+          model
+        else
+          raise Errors::RemoteWrite.new(self.class)
+        end
       end
 
       def destroy(*args)

--- a/lib/graphiti/schema.rb
+++ b/lib/graphiti/schema.rb
@@ -49,6 +49,8 @@ module Graphiti
     def generate_endpoints
       {}.tap do |endpoints|
         @resources.each do |r|
+          next if r.remote?
+
           r.endpoints.each do |e|
             actions = {}
             e[:actions].each do |a|

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -47,7 +47,6 @@ module Graphiti
       end
 
       if remote?
-        @link = false
         @resource_class = create_remote_resource
       end
     end

--- a/lib/graphiti/sideload/belongs_to.rb
+++ b/lib/graphiti/sideload/belongs_to.rb
@@ -23,8 +23,17 @@ class Graphiti::Sideload::BelongsTo < Graphiti::Sideload
   end
 
   def infer_foreign_key
-    if polymorphic_child?
-      parent.foreign_key
+    return parent.foreign_key if polymorphic_child?
+
+    if resource.remote?
+      namespace = namespace_for(resource.class)
+      resource_name = resource.class.name
+        .gsub("#{namespace}::", "")
+        .gsub("Resource", "")
+      if resource_name.include?(".remote")
+        resource_name = resource_name.split(".remote")[0].split(".")[1]
+      end
+      :"#{resource_name.singularize.underscore}_id"
     else
       model = resource.model
       namespace = namespace_for(model)

--- a/lib/graphiti/util/serializer_relationships.rb
+++ b/lib/graphiti/util/serializer_relationships.rb
@@ -109,6 +109,8 @@ module Graphiti
       end
 
       def validate_link_for_sideload!(sideload)
+        return if sideload.resource.remote?
+
         action = sideload.type == :belongs_to ? :show : :index
         cache_key = :"#{@sideload.object_id}-#{action}"
         return if self.class.validated_link_cache.include?(cache_key)

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -395,7 +395,7 @@ RSpec.describe "filtering" do
     end
 
     context "when allow list is omitted" do
-      context 'when using a string_enum field' do
+      context "when using a string_enum field" do
         it "raises an error at load time" do
           expect {
             resource.filter :enum_first_name, :string_enum do
@@ -408,7 +408,7 @@ RSpec.describe "filtering" do
         end
       end
 
-      context 'when using an integer_enum field' do
+      context "when using an integer_enum field" do
         it "raises an error at load time" do
           expect {
             resource.filter :enum_age, :integer_enum do

--- a/spec/remote_resource_spec.rb
+++ b/spec/remote_resource_spec.rb
@@ -777,10 +777,32 @@ RSpec.describe "remote resources" do
     end
 
     context "when updating" do
-      it "raises error" do
-        expect {
-          klass.find(id: 1, data: {type: "employees"}).update_attributes
-        }.to raise_error(Graphiti::Errors::RemoteWrite, /not supported/)
+      let(:payload) do
+        {
+          data: {
+            type: "employees",
+            id: "123",
+            attributes: {last_name: "Jane"},
+          },
+        }
+      end
+
+      context "and only associating to a remote parent" do
+        before do
+          payload[:data].delete(:attributes)
+        end
+
+        it "works" do
+          klass.find(payload).update_attributes
+        end
+      end
+
+      context "and passing more attributes than simple association" do
+        it "raises error" do
+          expect {
+            klass.find(payload).update_attributes
+          }.to raise_error(Graphiti::Errors::RemoteWrite, /not supported/)
+        end
       end
     end
 

--- a/spec/schema_diff_spec.rb
+++ b/spec/schema_diff_spec.rb
@@ -126,8 +126,9 @@ RSpec.describe Graphiti::SchemaDiff do
         end
       end
 
-      it "does not diff" do
-        expect(diff).to eq([])
+      it "notes only the newly-missing missing endpoint" do
+        expect(diff)
+          .to eq(["Endpoint \"/schema_diff/employees\" was removed."])
       end
     end
 

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Graphiti::Schema do
           },
           integer_enum: {
             description: "Integer enum type. Like a normal integer, but only eq/!eq filters. Limited to only the allowed values.",
-            kind: "scalar"
+            kind: "scalar",
           },
           integer: {
             kind: "scalar",
@@ -587,6 +587,16 @@ RSpec.describe Graphiti::Schema do
         expect(endpoint[:actions][:index][:sideload_allowlist]).to eq({
           positions: {department: {}},
         })
+      end
+    end
+
+    context "when a resource is remote" do
+      before do
+        employee_resource.remote = "http://foo.com/employees"
+      end
+
+      it "does not add endpoints to the schema" do
+        expect(schema[:endpoints]).to eq({})
       end
     end
 

--- a/spec/sideload_spec.rb
+++ b/spec/sideload_spec.rb
@@ -208,6 +208,59 @@ RSpec.describe Graphiti::Sideload do
         expect(instance.infer_foreign_key).to eq(:sideload_spec_employee_id)
       end
     end
+
+    context "when the resource is remote" do
+      let(:name) { "positions" }
+
+      context "via the sideload :remote option" do
+        it "is inferred correctly from the parent resource" do
+          opts.delete(:resource)
+          opts[:remote] = "http://foo.com/positions"
+          expect(instance.infer_foreign_key).to eq(:employee_id)
+        end
+
+        context "and belongs_to" do
+          let(:instance) { Class.new(Graphiti::Sideload::BelongsTo).new(name, opts) }
+
+          before do
+            opts[:type] = :belongs_to
+          end
+
+          it "works" do
+            opts.delete(:resource)
+            opts[:remote] = "http://foo.com/positions"
+            expect(instance.infer_foreign_key).to eq(:position_id)
+          end
+        end
+      end
+
+      context "via resource class" do
+        before do
+          opts[:resource] = Class.new(Graphiti::Resource) do
+            self.remote = "http://foo.com"
+            def self.name
+              "PORO::PositionResource"
+            end
+          end
+        end
+
+        it "is inferred correctly from the parent resource" do
+          expect(instance.infer_foreign_key).to eq(:employee_id)
+        end
+
+        context "and belongs_to" do
+          let(:instance) { Class.new(Graphiti::Sideload::BelongsTo).new(name, opts) }
+
+          before do
+            opts[:type] = :belongs_to
+          end
+
+          it "works" do
+            expect(instance.infer_foreign_key).to eq(:position_id)
+          end
+        end
+      end
+    end
   end
 
   describe "#ids_for_parents" do


### PR DESCRIPTION
* Previously, we'd disallow all writes. Now we allow associating to an
existing remote entity (only applies to `belongs_to).
* Previously, we'd avoid links for remote resources. Now, we avoid link
validation (because we can't validate a remote API), but still generate
the links (you can of course always turn this off).
* As part of the last point, improved foreign key inferrence. We usually
infer FK via the model name, but for remote resources the model is
OpenStruct so we should use the resource name instead.