### PR TITLE
Throw better error when polymorphic type not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### master (unreleased)
 
+Misc:
+
+- [#123](https://github.com/graphiti-api/graphiti/pull/123) Throw
+  better error when polymorphic type not found.
+
 <!-- ### [version (YYYY-MM-DD)](diff_link) -->
 <!-- Breaking changes:-->
 <!-- Features:-->

--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -561,6 +561,28 @@ module Graphiti
       end
     end
 
+    class PolymorphicSideloadTypeNotFound < Base
+      def initialize(sideload, name)
+        @sideload = sideload
+        @name = name
+      end
+
+      def message
+        <<~MSG
+          #{@sideload.parent_resource}: Tried to find a Resource with type '#{@name.inspect}', but did not find one!
+
+          This is because either a Resource with that type doesn't exist, or it's not registered on the sideload. The below example shows how to register a Resource with this sideload. Make sure one of the registered Resources has type '#{@name.inspect}'
+
+          polymorphic_belongs_to #{@sideload.name.inspect} do
+            group_by(#{@sideload.grouper.field_name.inspect}) do
+              on(:foo)
+              on(:foo).belongs_to :foo, resource: FooResource # (long-hand example)
+            end
+          end
+        MSG
+      end
+    end
+
     class PolymorphicSideloadChildNotFound < Base
       def initialize(sideload, name)
         @sideload = sideload

--- a/lib/graphiti/sideload/polymorphic_belongs_to.rb
+++ b/lib/graphiti/sideload/polymorphic_belongs_to.rb
@@ -99,6 +99,15 @@ class Graphiti::Sideload::PolymorphicBelongsTo < Graphiti::Sideload::BelongsTo
     end
   end
 
+  def child_for_type!(type)
+    if (child = child_for_type(type))
+      child
+    else
+      err = ::Graphiti::Errors::PolymorphicSideloadTypeNotFound
+      raise err.new(self, type)
+    end
+  end
+
   def resolve(parents, query, graph_parent)
     parents.group_by(&grouper.field_name).each_pair do |group_name, group|
       next if group_name.nil? || grouper.ignore?(group_name)

--- a/lib/graphiti/util/relationship_payload.rb
+++ b/lib/graphiti/util/relationship_payload.rb
@@ -47,7 +47,7 @@ module Graphiti
 
         # For polymorphic *sideloads*, grab the correct child sideload
         if sideload.resource.type != type && sideload.type == :polymorphic_belongs_to
-          sideload = sideload.child_for_type(type)
+          sideload = sideload.child_for_type!(type)
         end
 
         # For polymorphic *resources*, grab the correct child resource

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -390,7 +390,7 @@ RSpec.describe "filtering" do
         params[:filter] = {enum_age: {eq: 2}}
         expect {
           records
-        }.to raise_error(Graphiti::Errors::InvalidFilterValue, /Allowlist: \[1, 3, 5]/)
+        }.to raise_error(Graphiti::Errors::InvalidFilterValue, /Allowlist: \[1, 3, 5\]/)
       end
     end
 

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -2439,6 +2439,7 @@ RSpec.describe "persistence" do
     end
 
     describe "polymorphic_belongs_to" do
+      let(:jsonapi_type) { "visas" }
       let(:payload) do
         {
           data: {
@@ -2446,7 +2447,7 @@ RSpec.describe "persistence" do
             relationships: {
               credit_card: {
                 data: {
-                  type: "visas",
+                  type: jsonapi_type,
                   'temp-id': "abc123",
                   method: "create",
                 },
@@ -2456,7 +2457,7 @@ RSpec.describe "persistence" do
           included: [
             {
               'temp-id': "abc123",
-              type: "visas",
+              type: jsonapi_type,
               attributes: {number: 123456},
             },
           ],
@@ -2504,6 +2505,16 @@ RSpec.describe "persistence" do
         expect(data.credit_card.id).to be_present
         expect(data.credit_card.number).to eq(123456)
         expect(data.credit_card_type).to eq(:Visa)
+      end
+
+      context "when unknown jsonapi type" do
+        let(:jsonapi_type) { "foos" }
+
+        it "raises helpful error" do
+          expect {
+            klass.build(payload).save
+          }.to raise_error(Graphiti::Errors::PolymorphicSideloadTypeNotFound)
+        end
       end
     end
 


### PR DESCRIPTION
If you are sideposting a polymorphic relationship, and pass a jsonapi
type that is not registered, we would throw a confusing error. Now we
throw an explicit error with information about what's happening.