### PR TITLE
Defer serializer relationships when eager loading

### DIFF
--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -10,7 +10,6 @@ module Graphiti
           if val
             if super(Class.new(val))
               apply_attributes_to_serializer
-              apply_sideloads_to_serializer
             end
           else
             super

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -67,6 +67,34 @@ RSpec.describe Graphiti::Resource do
         expect(klass.relationships_writable_by_default).to eq(true)
       end
 
+      context 'when rails' do
+        before do
+          rails = double \
+            application: double(config: double(eager_load: eager_load))
+          stub_const('Rails', rails)
+        end
+
+        context 'and eager loading' do
+          let(:eager_load) { true }
+
+          it 'does NOT assign relationships to the serializer' do
+            klass.has_many :positions, resource: PORO::PositionResource
+            expect(klass.serializer.relationship_blocks).to be_blank
+            Graphiti.setup!
+            expect(klass.serializer.relationship_blocks).to_not be_blank
+          end
+        end
+
+        context 'and NOT eager loading' do
+          let(:eager_load) { false }
+
+          it 'assigns relationships to the serializer' do
+            klass.has_many :positions, resource: PORO::PositionResource
+            expect(klass.serializer.relationship_blocks).to_not be_blank
+          end
+        end
+      end
+
       context "when assigning new adapter" do
         let(:adapter) do
           Class.new(Graphiti::Adapters::Abstract) do


### PR DESCRIPTION
To do endpoint validation, we register a proc in railtie.rb that checks
routes. For this to work, all resources and routes must be loaded. This
is a problem because the resource classes load before routes are
finished, and we want to do this at boot instead of runtime for
performance.

The solution is to defer the link validation until the app has loaded
*and* we've reloaded routes. This happens in railtie.rb, but it looks
like a straggler line would not defer, only under very specific
scenarios (when eager loading in production with polymorphic resources,
*and* a particular load order).

I've removed the straggler line to ensure this works as intended.