### PR TITLE
Remove except from spec generators

### DIFF
--- a/lib/generators/graphiti/templates/create_request_spec.rb.erb
+++ b/lib/generators/graphiti/templates/create_request_spec.rb.erb
@@ -8,8 +8,7 @@ RSpec.describe "<%= type %>#create", type: :request do
   describe 'basic create' do
     let(:params) do
       <%- if defined?(FactoryBot) -%>
-      attributes_for(:<%= type.to_s.singularize %>).
-        except("created_at", "updated_at")
+      attributes_for(:<%= type.to_s.singularize %>)
       <%- else -%>
       {
         # ... your attrs here

--- a/lib/generators/graphiti/templates/resource_writes_spec.rb.erb
+++ b/lib/generators/graphiti/templates/resource_writes_spec.rb.erb
@@ -7,8 +7,7 @@ RSpec.describe <%= resource_class %>, type: :resource do
         data: {
           type: '<%= type %>',
       <%- if defined?(FactoryBot) -%>
-          attributes: attributes_for(:<%= type.to_s.singularize %>).
-            except("created_at", "updated_at")
+          attributes: attributes_for(:<%= type.to_s.singularize %>)
        <%- else -%>
           attributes: { }
        <%- end -%>


### PR DESCRIPTION
`except("created_at", "updated_at")` is irrelevant when using
`attributes_for`. This is a relic from using `build(..).attributes`
instead of `attributes_for`.

The former returns a hash with keys as strings along with
"created_at", "updated_at" and any dependent foreign keys. The latter
returns just the attributes with keys as symbols.

```
2.6.1 :001 > FactoryBot.build(:post).attributes.except("created_at", "title")
   (0.1ms)  BEGIN
  User Create (1.2ms)  INSERT INTO "users" ("created_at", "updated_at") VALUES ($1, $2) RETURNING "id"  [["created_at", "2019-04-26 05:37:54.694869"], ["updated_at", "2019-04-26 05:37:54.694869"]]
   (0.9ms)  COMMIT
 => {"id"=>nil, "upvotes"=>1, "active"=>false, "updated_at"=>nil, "user_id"=>"b1a94aec-a29d-49d1-b431-b754a6935ab9"}
2.6.1 :002 > FactoryBot.attributes_for(:post).except(:title)
 => {:upvotes=>1, :active=>false}
```