### PR TITLE
Fix remote sideload belongs_to links

### DIFF
--- a/lib/graphiti/util/link.rb
+++ b/lib/graphiti/util/link.rb
@@ -59,7 +59,7 @@ module Graphiti
 
       def params
         @params ||= {}.tap do |params|
-          if @sideload.type != :belongs_to
+          if @sideload.type != :belongs_to || @sideload.remote?
             params[:filter] = @sideload.base_filter([@model])
           end
 
@@ -70,7 +70,7 @@ module Graphiti
       def path
         @path ||=
           path = @sideload.resource.endpoint[:url].to_s
-        if @sideload.type == :belongs_to
+        if @sideload.type == :belongs_to && !@sideload.remote?
           path = "#{path}/#{@model.send(@sideload.foreign_key)}"
         end
         path

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -1185,7 +1185,7 @@ RSpec.describe "serialization" do
             render
             credit_card = json["data"][0]["relationships"]["credit_card"]
             expect(credit_card["links"]["related"])
-              .to eq("http://foo.com/mastercards/789")
+              .to eq("http://foo.com/mastercards?filter[id]=789")
           end
         end
 
@@ -1351,7 +1351,25 @@ RSpec.describe "serialization" do
               remote: "http://foo.com/classifications"
             render
             expect(classification["links"]["related"])
-              .to eq("http://foo.com/classifications/789")
+              .to eq("http://foo.com/classifications?filter[id]=789")
+          end
+
+          # Special case because we hit index with a filter
+          context 'and params are customized' do
+            before do
+              resource.belongs_to :classification,
+                remote: "http://foo.com/classifications" do
+                  params do |hash|
+                    hash[:filter][:foo] = 'bar'
+                  end
+                end
+            end
+
+            it 'links correctly' do
+              render
+              expect(classification["links"]["related"])
+                .to eq("http://foo.com/classifications?filter[foo]=bar&filter[id]=789")
+            end
           end
         end
       end


### PR DESCRIPTION
These would point to the `show` action, as they do when linking locally.
However, remote belongs_to queries actually hit `index`.

You could make a case that we should fix this inconsistency, and I would
support a configuration option to do so. As it stands, that would A)
break backwards-compatibility B) possibly have the downside of alternate
remote logic based on relationship type C) hit caching and other
customizations related to `show` that might not be desired.

This PR just fixes the issue - correct link generation, and avoiding
errors when the `filter` param is customized.