### PR TITLE
Remove unused Errors::UnwritableRelationship

### DIFF
--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -86,19 +86,6 @@ module Graphiti
       end
     end
 
-    class UnwritableRelationship < Base
-      def initialize(resource, sideload)
-        @resource = resource
-        @sideload = sideload
-      end
-
-      def message
-        <<-MSG
-          #{@resource.class}: Tried to persist association #{@sideload.name.inspect} but marked writable: false
-        MSG
-      end
-    end
-
     class SingularSideload < Base
       def initialize(sideload, parent_length)
         @sideload = sideload


### PR DESCRIPTION
This is no longer thrown, as the logic has been moved into the
`RequestValidator` class and is one of many error messages that can be
applied to a request errors object.