### PR TITLE
Refactor debugging for better details on manually scoped sideloads

### DIFF
--- a/lib/graphiti/debugger.rb
+++ b/lib/graphiti/debugger.rb
@@ -59,9 +59,10 @@ module Graphiti
         add_chunk(payload[:resource], payload[:parent]) do |logs, json|
           logs << [" \\_ #{sideload.name}", :yellow, true]
           json[:name] = sideload.name
-          query = "#{payload[:resource].class.name}.all(#{params.inspect})"
-          unless payload[:resource]
-            query = "#{sideload.resource.class.name}: Manual sideload via .scope"
+          if sideload.class.scope_proc
+            query = "#{payload[:resource].class.name}: Manual sideload via .scope"
+          else
+            query = "#{payload[:resource].class.name}.all(#{params.inspect})"
           end
           logs << ["    #{query}", :cyan, true]
           json[:query] = query

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -249,19 +249,16 @@ module Graphiti
       end
 
       if self.class.scope_proc
-        Graphiti.broadcast("data", resource_class: resource.class, sideload: self) do |payload|
-          sideload_scope = fire_scope(parents)
-          sideload_scope = Scope.new sideload_scope,
-            resource,
-            query,
-            parent: graph_parent,
-            sideload: self,
-            sideload_parent_length: parents.length,
-            default_paginate: false
-          sideload_scope.resolve do |sideload_results|
-            payload[:results] = sideload_results
-            fire_assign(parents, sideload_results)
-          end
+        sideload_scope = fire_scope(parents)
+        sideload_scope = Scope.new sideload_scope,
+          resource,
+          query,
+          parent: graph_parent,
+          sideload: self,
+          sideload_parent_length: parents.length,
+          default_paginate: false
+        sideload_scope.resolve do |sideload_results|
+          fire_assign(parents, sideload_results)
         end
       else
         load(parents, query, graph_parent)


### PR DESCRIPTION
Before:

```
D, [2019-05-17T10:51:19.531351 #83814] DEBUG -- : Top Level Data Retrieval (+ sideloads):
D, [2019-05-17T10:51:19.531390 #83814] DEBUG -- : PORO::EmployeeResource.all({})
D, [2019-05-17T10:51:19.531413 #83814] DEBUG -- : Took: 0.05ms
D, [2019-05-17T10:51:19.531439 #83814] DEBUG -- :     \_ positions
D, [2019-05-17T10:51:19.531458 #83814] DEBUG -- :        PORO::PositionResource.all({})
D, [2019-05-17T10:51:19.531476 #83814] DEBUG -- :        Took: 0.03ms
D, [2019-05-17T10:51:19.531495 #83814] DEBUG -- :        \_ department
D, [2019-05-17T10:51:19.531521 #83814] DEBUG -- :           PORO::DepartmentResource.all({})
D, [2019-05-17T10:51:19.531547 #83814] DEBUG -- :           Took: 0.02ms
D, [2019-05-17T10:51:19.531576 #83814] DEBUG -- :  \_ department
D, [2019-05-17T10:51:19.531603 #83814] DEBUG -- :     PORO::DepartmentResource: Manual sideload via .scope
D, [2019-05-17T10:51:19.532712 #83814] DEBUG -- :     Took: 0.14ms
D, [2019-05-17T10:51:19.532785 #83814] DEBUG -- :  \_ positions
D, [2019-05-17T10:51:19.532814 #83814] DEBUG -- :     PORO::PositionResource: Manual sideload via .scope
D, [2019-05-17T10:51:19.532839 #83814] DEBUG -- :     Took: 1.07ms
```

After:

```
D, [2019-05-17T11:13:49.603983 #85877] DEBUG -- : Top Level Data Retrieval (+ sideloads):
D, [2019-05-17T11:13:49.604007 #85877] DEBUG -- : PORO::EmployeeResource.all({})
D, [2019-05-17T11:13:49.604028 #85877] DEBUG -- : Took: 1.32ms
D, [2019-05-17T11:13:49.604050 #85877] DEBUG -- :     \_ positions
D, [2019-05-17T11:13:49.604071 #85877] DEBUG -- :        PORO::PositionResource: Manual sideload via .scope
D, [2019-05-17T11:13:49.604091 #85877] DEBUG -- :        Took: 0.06ms
D, [2019-05-17T11:13:49.604111 #85877] DEBUG -- :        \_ department
D, [2019-05-17T11:13:49.604138 #85877] DEBUG -- :           PORO::DepartmentResource: Manual sideload via .scope
D, [2019-05-17T11:13:49.604169 #85877] DEBUG -- :           Took: 0.04ms
```