### PR TITLE
Lock version of jsonapi-renderer

### DIFF
--- a/graphiti.gemspec
+++ b/graphiti.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.3"
 
   spec.add_dependency "jsonapi-serializable", "~> 0.3.0"
+  spec.add_dependency "jsonapi-renderer", "0.2.0"
   spec.add_dependency "dry-types", "~> 0.15"
   spec.add_dependency "graphiti_errors", "~> 1.1.0"
   spec.add_dependency "concurrent-ruby", "~> 1.0"

--- a/lib/graphiti/version.rb
+++ b/lib/graphiti/version.rb
@@ -1,3 +1,3 @@
 module Graphiti
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end


### PR DESCRIPTION
Per Slack:

Tom Luce [12:08 PM]
One thing I did find today @richmolj is that I believe that the latest version of the jsonapi-renderer gem (0.2.1) introduces a breaking change.  Specifically:  When including resources that have an underscore in their name (e.g. careers_pages/1?include=careers_pages_blocks) the renderer now throws an InvalidKey error because the name doesn't match a regex they've introduced.

It's not an issue with Graphiti per-say but I thought i'd flag it as something worth noting because i've burnt some time getting to the bottom of it.  I'll have to raise a separate issue on the renderer gem to change the regex to allow underscores,  but in the meantime locking the version to 0.2.0 is the only way to get Graphiti to work properly! (edited)

If you're interested you can see the change here -> https://github.com/jsonapi-rb/jsonapi-renderer/compare/v0.2.0...v0.2.1