### PR TITLE
Allow attribute to be used, but not to show up in the schema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+Features:
+
+- [157](https://github.com/graphiti-api/graphiti/pull/157) Using attribute option schema: false.
+  This option is default true and is not effected by only and except options. (@zeisler)
+
 ## 1.1.0
 
 Features:

--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -78,6 +78,7 @@ module Graphiti
           :attributes_writable_by_default,
           :attributes_sortable_by_default,
           :attributes_filterable_by_default,
+          :attributes_schema_by_default,
           :relationships_readable_by_default,
           :relationships_writable_by_default
 
@@ -97,6 +98,7 @@ module Graphiti
           default(klass, :attributes_writable_by_default, true)
           default(klass, :attributes_sortable_by_default, true)
           default(klass, :attributes_filterable_by_default, true)
+          default(klass, :attributes_schema_by_default, true)
           default(klass, :relationships_readable_by_default, true)
           default(klass, :relationships_writable_by_default, true)
 

--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -101,6 +101,7 @@ module Graphiti
           attribute_option(options, :writable)
           attribute_option(options, :sortable)
           attribute_option(options, :filterable)
+          attribute_option(options, :schema, true)
           options[:type] = type
           options[:proc] = blk
           config[:attributes][name] = options
@@ -151,11 +152,11 @@ module Graphiti
           Util::SerializerAttributes.new(self, extra_attributes, true).apply
         end
 
-        def attribute_option(options, name)
+        def attribute_option(options, name, exclusive = false)
           if options[name] != false
-            default = if (only = options[:only])
+            default = if (only = options[:only]) && !exclusive
               Array(only).include?(name) ? true : false
-            elsif (except = options[:except])
+            elsif (except = options[:except]) && !exclusive
               Array(except).include?(name) ? false : true
             else
               send(:"attributes_#{name}_by_default")

--- a/lib/graphiti/schema.rb
+++ b/lib/graphiti/schema.rb
@@ -131,7 +131,7 @@ module Graphiti
     def attributes(resource)
       {}.tap do |attrs|
         resource.attributes.each_pair do |name, config|
-          if config.values_at(:readable, :writable).any?
+          if config.values_at(:readable, :writable).any? && config[:schema]
             attrs[name] = {
               type: config[:type].to_s,
               readable: flag(config[:readable]),
@@ -166,6 +166,8 @@ module Graphiti
     def sorts(resource)
       {}.tap do |s|
         resource.sorts.each_pair do |name, sort|
+          next unless resource.attributes[name][:schema]
+
           config = {}
           config[:only] = sort[:only] if sort[:only]
           attr = resource.attributes[name]
@@ -180,6 +182,8 @@ module Graphiti
     def filters(resource)
       {}.tap do |f|
         resource.filters.each_pair do |name, filter|
+          next unless resource.attributes[name][:schema]
+
           config = {
             type: filter[:type].to_s,
             operators: filter[:operators].keys.map(&:to_s),

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Graphiti::Resource do
         expect(klass.attributes_writable_by_default).to eq(true)
         expect(klass.attributes_sortable_by_default).to eq(true)
         expect(klass.attributes_filterable_by_default).to eq(true)
+        expect(klass.attributes_schema_by_default).to eq(true)
         expect(klass.relationships_readable_by_default).to eq(true)
         expect(klass.relationships_writable_by_default).to eq(true)
       end
@@ -63,6 +64,7 @@ RSpec.describe Graphiti::Resource do
         expect(klass.attributes_writable_by_default).to eq(true)
         expect(klass.attributes_sortable_by_default).to eq(true)
         expect(klass.attributes_filterable_by_default).to eq(true)
+        expect(klass.attributes_schema_by_default).to eq(true)
         expect(klass.relationships_readable_by_default).to eq(true)
         expect(klass.relationships_writable_by_default).to eq(true)
       end
@@ -147,6 +149,7 @@ RSpec.describe Graphiti::Resource do
             self.attributes_writable_by_default = false
             self.attributes_sortable_by_default = false
             self.attributes_filterable_by_default = false
+            self.attributes_schema_by_default = false
             self.relationships_readable_by_default = false
             self.relationships_writable_by_default = false
           end
@@ -160,6 +163,7 @@ RSpec.describe Graphiti::Resource do
           expect(klass.attributes_writable_by_default).to eq(false)
           expect(klass.attributes_sortable_by_default).to eq(false)
           expect(klass.attributes_filterable_by_default).to eq(false)
+          expect(klass.attributes_schema_by_default).to eq(false)
           expect(klass.relationships_readable_by_default).to eq(false)
           expect(klass.relationships_writable_by_default).to eq(false)
         end
@@ -288,6 +292,7 @@ RSpec.describe Graphiti::Resource do
             self.attributes_writable_by_default = false
             self.attributes_sortable_by_default = false
             self.attributes_filterable_by_default = false
+            self.attributes_schema_by_default = false
             self.relationships_readable_by_default = false
             self.relationships_writable_by_default = false
           end
@@ -301,6 +306,7 @@ RSpec.describe Graphiti::Resource do
           expect(klass2.attributes_writable_by_default).to eq(false)
           expect(klass2.attributes_sortable_by_default).to eq(false)
           expect(klass2.attributes_filterable_by_default).to eq(false)
+          expect(klass2.attributes_schema_by_default).to eq(false)
           expect(klass2.relationships_readable_by_default).to eq(false)
           expect(klass2.relationships_writable_by_default).to eq(false)
         end
@@ -564,6 +570,7 @@ RSpec.describe Graphiti::Resource do
       expect(attribute[:writable]).to eq(true)
       expect(attribute[:sortable]).to eq(true)
       expect(attribute[:filterable]).to eq(true)
+      expect(attribute[:schema]).to eq(true)
     end
 
     context "when :only passed" do
@@ -578,6 +585,7 @@ RSpec.describe Graphiti::Resource do
           expect(att[:readable]).to eq(false)
           expect(att[:sortable]).to eq(false)
           expect(att[:writable]).to eq(false)
+          expect(att[:schema]).to eq(true)
         end
       end
 
@@ -592,6 +600,7 @@ RSpec.describe Graphiti::Resource do
           expect(att[:readable]).to eq(false)
           expect(att[:sortable]).to eq(true)
           expect(att[:writable]).to eq(false)
+          expect(att[:schema]).to eq(true)
         end
       end
 
@@ -607,6 +616,7 @@ RSpec.describe Graphiti::Resource do
           expect(att[:readable]).to eq(false)
           expect(att[:sortable]).to eq(false)
           expect(att[:writable]).to eq(false)
+          expect(att[:schema]).to eq(true)
         end
       end
     end
@@ -623,6 +633,7 @@ RSpec.describe Graphiti::Resource do
           expect(att[:readable]).to eq(true)
           expect(att[:sortable]).to eq(true)
           expect(att[:writable]).to eq(false)
+          expect(att[:schema]).to eq(true)
         end
       end
 
@@ -637,6 +648,7 @@ RSpec.describe Graphiti::Resource do
           expect(att[:readable]).to eq(true)
           expect(att[:sortable]).to eq(false)
           expect(att[:writable]).to eq(false)
+          expect(att[:schema]).to eq(true)
         end
       end
     end
@@ -652,6 +664,7 @@ RSpec.describe Graphiti::Resource do
         expect(att[:readable]).to eq(true)
         expect(att[:sortable]).to eq(:admin?)
         expect(att[:writable]).to eq(false)
+        expect(att[:schema]).to eq(true)
       end
     end
 
@@ -737,6 +750,7 @@ RSpec.describe Graphiti::Resource do
           self.attributes_writable_by_default = false
           self.attributes_sortable_by_default = false
           self.attributes_filterable_by_default = false
+          self.attributes_schema_by_default = false
         end
       end
 
@@ -747,6 +761,7 @@ RSpec.describe Graphiti::Resource do
         expect(attribute[:writable]).to eq(false)
         expect(attribute[:sortable]).to eq(false)
         expect(attribute[:filterable]).to eq(false)
+        expect(attribute[:schema]).to eq(false)
       end
     end
 
@@ -809,6 +824,17 @@ RSpec.describe Graphiti::Resource do
       it "overrides the default" do
         attribute = klass.config[:attributes][:foo]
         expect(attribute[:filterable]).to eq(false)
+      end
+    end
+
+    context "when explicit schema flag" do
+      before do
+        klass.attribute :foo, :string, schema: false
+      end
+
+      it "overrides the default" do
+        attribute = klass.config[:attributes][:foo]
+        expect(attribute[:schema]).to eq(false)
       end
     end
 

--- a/spec/schema_diff_spec.rb
+++ b/spec/schema_diff_spec.rb
@@ -240,6 +240,20 @@ RSpec.describe Graphiti::SchemaDiff do
       it { is_expected.to eq([]) }
     end
 
+    context "when attribute goes schema true to false" do
+      before do
+        resource_b.attribute :first_name, :string, schema: false
+      end
+
+      it "returns error" do
+        expect(diff).to eq([
+                             "SchemaDiff::EmployeeResource: attribute :first_name was removed.",
+                             "SchemaDiff::EmployeeResource: sort :first_name was removed.",
+                             "SchemaDiff::EmployeeResource: filter :first_name was removed."
+                           ])
+      end
+    end
+
     context "when attribute is removed" do
       before do
         resource_b

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Graphiti::Schema do
         self.description = "An employee of the organization"
 
         attribute :first_name, :string, description: "The employee's first name"
-
+        attribute :hidden_attribute, :string, schema: false
         extra_attribute :net_sales, :float, description: "The total value of the employee's sales"
 
         filter :title, :string do
@@ -270,8 +270,6 @@ RSpec.describe Graphiti::Schema do
         expect(schema[:resources][0][:name]).to eq("Schema::PositionResource")
       end
     end
-
-    context
 
     context "when attribute is not readable" do
       before do
@@ -487,6 +485,19 @@ RSpec.describe Graphiti::Schema do
       it "reflects them in the schema" do
         expect(schema[:resources][0][:filters][:first_name][:dependencies])
           .to eq(["foo"])
+      end
+    end
+
+    context "when attribute changes to schema true" do
+      before do
+        employee_resource.class_eval do
+          attribute :hidden_attribute, :string, schema: true
+        end
+      end
+
+      it "is readable" do
+        expect(schema[:resources][0][:attributes][:hidden_attribute][:readable])
+          .to eq(true)
       end
     end
 


### PR DESCRIPTION
Using attribute option `schema: false`.
This option is default true and is not effected by `only` and
`except` options.