### PR TITLE
Option to coerce "null" to Ruby nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Features:
 
+- [158](https://github.com/graphiti-api/graphiti/pull/158) Filters options `allow_nil: true`
+  Option can be set at the resource level `Resource.filters_accept_nil_by_default = true`. 
+  By default this is set to false. (@zeisler)
 - [157](https://github.com/graphiti-api/graphiti/pull/157) Using attribute option schema: false.
   This option is default true and is not effected by only and except options. (@zeisler)
 

--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -80,7 +80,8 @@ module Graphiti
           :attributes_filterable_by_default,
           :attributes_schema_by_default,
           :relationships_readable_by_default,
-          :relationships_writable_by_default
+          :relationships_writable_by_default,
+          :filters_accept_nil_by_default
 
         class << self
           prepend Overrides
@@ -101,6 +102,7 @@ module Graphiti
           default(klass, :attributes_schema_by_default, true)
           default(klass, :relationships_readable_by_default, true)
           default(klass, :relationships_writable_by_default, true)
+          default(klass, :filters_accept_nil_by_default, false)
 
           unless klass.config[:attributes][:id]
             klass.attribute :id, :integer_id

--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -32,6 +32,7 @@ module Graphiti
               dependencies: opts[:dependent],
               required: required,
               operators: operators.to_hash,
+              allow_nil: opts.fetch(:allow_nil, filters_accept_nil_by_default)
             }
           elsif (type = args[0])
             attribute name, type, only: [:filterable], allow: opts[:allow]

--- a/lib/graphiti/scoping/filter.rb
+++ b/lib/graphiti/scoping/filter.rb
@@ -54,6 +54,7 @@ module Graphiti
           unless type[:canonical_name] == :hash || !value.is_a?(String)
             value = parse_string_value(filter.values[0], value)
           end
+          value = parse_string_null(filter.values[0], value)
           validate_singular(resource, filter, value)
           value = coerce_types(filter.values[0], param_name.to_sym, value)
           validate_allowlist(resource, filter, value)
@@ -181,6 +182,12 @@ module Graphiti
       # remove any blanks that are left
       value.reject! { |v| v.length.zero? }
       value = value[0] if value.length == 1
+      value
+    end
+
+    def parse_string_null(filter, value)
+      return if value == "null" && filter[:allow_nil]
+
       value
     end
   end

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -202,6 +202,48 @@ RSpec.describe "filtering" do
     end
   end
 
+  context "when passed null and filter marked allow_nil: true" do
+    context "with string type" do
+      before do
+        resource.filter :first_name, allow_nil: true
+        employee2.update_attributes(first_name: nil)
+        params[:filter] = { first_name: "null" }
+      end
+
+      it "works" do
+        expect(records.map(&:id)).to eq([employee2.id])
+      end
+    end
+
+    context "with integer type" do
+      before do
+        resource.attribute :age, :integer
+        resource.filter :age, allow_nil: true
+        employee1.update_attributes(age: 20)
+        employee2.update_attributes(age: nil)
+        employee3.update_attributes(age: 30)
+        employee4.update_attributes(age: 40)
+        params[:filter] = { age: "null" }
+      end
+
+      it "works" do
+        expect(records.map(&:id)).to eq([employee2.id])
+      end
+    end
+  end
+
+  context "when passed null" do
+    before do
+      resource.filter :first_name
+      employee2.update_attributes(first_name: "null")
+      params[:filter] = {first_name: "null"}
+    end
+
+    it "defaults to a string" do
+      expect(records.map(&:id)).to eq([employee2.id])
+    end
+  end
+
   context "when passed comma, but filter marked single: true" do
     before do
       resource.filter :first_name, single: true

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Graphiti::Resource do
         expect(klass.attributes_schema_by_default).to eq(true)
         expect(klass.relationships_readable_by_default).to eq(true)
         expect(klass.relationships_writable_by_default).to eq(true)
+        expect(klass.filters_accept_nil_by_default).to eq(false)
       end
 
       context "when rails" do
@@ -152,6 +153,7 @@ RSpec.describe Graphiti::Resource do
             self.attributes_schema_by_default = false
             self.relationships_readable_by_default = false
             self.relationships_writable_by_default = false
+            self.filters_accept_nil_by_default = false
           end
         end
 
@@ -166,6 +168,7 @@ RSpec.describe Graphiti::Resource do
           expect(klass.attributes_schema_by_default).to eq(false)
           expect(klass.relationships_readable_by_default).to eq(false)
           expect(klass.relationships_writable_by_default).to eq(false)
+          expect(klass.filters_accept_nil_by_default).to eq(false)
         end
       end
 
@@ -295,6 +298,7 @@ RSpec.describe Graphiti::Resource do
             self.attributes_schema_by_default = false
             self.relationships_readable_by_default = false
             self.relationships_writable_by_default = false
+            self.filters_accept_nil_by_default = false
           end
         end
 
@@ -309,6 +313,7 @@ RSpec.describe Graphiti::Resource do
           expect(klass2.attributes_schema_by_default).to eq(false)
           expect(klass2.relationships_readable_by_default).to eq(false)
           expect(klass2.relationships_writable_by_default).to eq(false)
+          expect(klass2.filters_accept_nil_by_default).to eq(false)
         end
       end
 


### PR DESCRIPTION
Filters have new options `allow_nil: true`
Option can be set at the resource level `Resource.filters_accept_nil_by_default = true`
By default this is set to false.

#142