### PR TITLE
Add hook for attribute lookup `attribute_missing` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 Features:
 
-- [158](https://github.com/graphiti-api/graphiti/pull/158) Filters options `allow_nil: true`
+- [#159](https://github.com/graphiti-api/graphiti/pull/159) Defining the instance method `attribute_missing(attr)`
+  allows attributes to be added at runtime. (@zeisler)
+- [#158](https://github.com/graphiti-api/graphiti/pull/158) Filters options `allow_nil: true`
   Option can be set at the resource level `Resource.filters_accept_nil_by_default = true`. 
   By default this is set to false. (@zeisler)
-- [157](https://github.com/graphiti-api/graphiti/pull/157) Using attribute option schema: false.
+- [#157](https://github.com/graphiti-api/graphiti/pull/157) Using attribute option schema: false.
   This option is default true and is not effected by only and except options. (@zeisler)
 
 ## 1.1.0

--- a/lib/graphiti/resource/interface.rb
+++ b/lib/graphiti/resource/interface.rb
@@ -3,6 +3,9 @@ module Graphiti
     module Interface
       extend ActiveSupport::Concern
 
+      def attribute_missing(attr)
+      end
+
       class_methods do
         def all(params = {}, base_scope = nil)
           validate!(params)

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -1580,6 +1580,25 @@ RSpec.describe Graphiti::Resource do
         expect(att).to eq(klass.attributes[:foo])
       end
     end
+
+    context "when attribute goes through attribute_missing" do
+      before do
+        klass.redefine_method(:attribute_missing) do |attr|
+          self.class.attribute attr, :string if attr == :foobar
+        end
+      end
+
+      it "returns the attribute when handled by attribute_missing" do
+        att = instance.get_attr!(:foobar, :sortable, request: true)
+        expect(att).to eq(klass.attributes[:foobar])
+      end
+
+      it "raises helpful error when not handled by attribute_missing" do
+        expect {
+          instance.get_attr!(:bar, :sortable, request: true)
+        }.to raise_error(Graphiti::Errors::UnknownAttribute)
+      end
+    end
   end
 
   describe "#typecast" do


### PR DESCRIPTION
Defining the instance method `attribute_missing(attr)`
allows attributes to be added at runtime.

```ruby
class EmployeeResource < ApplicationResource
  def attribute_missing(attr)
    self.class.attribute attr, :string if attr == :dynamic_attribute
  end
end
```