### PR TITLE
Properly escape singular filters

### DIFF
--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -200,6 +200,16 @@ RSpec.describe "filtering" do
         expect(records.map(&:id)).to eq([employee2.id])
       end
     end
+
+    context 'and the filter is marked single: true' do
+      before do
+        resource.filter :first_name, :string, single: true
+      end
+
+      it 'works' do
+        expect(records.map(&:id)).to eq([employee2.id])
+      end
+    end
   end
 
   context "when passed null and filter marked allow_nil: true" do


### PR DESCRIPTION
0e2c4ddd05d5188d5 caused singular filters to avoid parsing the comma
into an array. However, it accidentally also prevented escaping special
characters. As a side effect, a `single: true` filter wrapped in `{{}}`
curlies would incorrectly see the value passed in containing `{{}}`.

This fixes things so singular filters still get parsed correctly, they
just avoid the comma/array scenario as originally intended.