### PR TITLE
Use linkage: always: true on belongs_to relationships

### DIFF
--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -42,6 +42,14 @@ module Graphiti
       @group_name            = opts[:group_name]
       @polymorphic_child     = opts[:polymorphic_child]
       @parent                = opts[:parent]
+
+      @linkage_always        = if opts[:linkage_always].nil?
+                                 # option not provided, use default
+                                 type == :belongs_to
+                               else
+                                 !!opts[:linkage_always]
+                               end
+
       if polymorphic_child?
         parent.resource.polymorphic << resource_class
       end
@@ -110,6 +118,10 @@ module Graphiti
 
     def polymorphic_has_many?
       !!@polymorphic_as
+    end
+
+    def linkage_always?
+      !!@linkage_always
     end
 
     def link?

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -18,37 +18,31 @@ module Graphiti
       :link_proc
 
     def initialize(name, opts)
-      @name = name
+      @name                          = name
       validate_options!(opts)
-      @parent_resource_class = opts[:parent_resource]
-      @resource_class        = opts[:resource]
-      @primary_key           = opts[:primary_key]
-      @foreign_key           = opts[:foreign_key]
-      @type                  = opts[:type]
-      @base_scope            = opts[:base_scope]
-      @readable              = opts[:readable]
-      @writable              = opts[:writable]
-      @as                    = opts[:as]
-      @link                  = opts[:link]
-      @single                = opts[:single]
-      @remote                = opts[:remote]
+      @parent_resource_class         = opts[:parent_resource]
+      @resource_class                = opts[:resource]
+      @primary_key                   = opts[:primary_key]
+      @foreign_key                   = opts[:foreign_key]
+      @type                          = opts[:type]
+      @base_scope                    = opts[:base_scope]
+      @readable                      = opts[:readable]
+      @writable                      = opts[:writable]
+      @as                            = opts[:as]
+      @link                          = opts[:link]
+      @single                        = opts[:single]
+      @remote                        = opts[:remote]
       apply_belongs_to_many_filter if type == :many_to_many
 
-      @description           = opts[:description]
+      @description                   = opts[:description]
 
       # polymorphic has_many
-      @polymorphic_as        = opts[:polymorphic_as]
+      @polymorphic_as                = opts[:polymorphic_as]
       # polymorphic_belongs_to-specific
-      @group_name            = opts[:group_name]
-      @polymorphic_child     = opts[:polymorphic_child]
-      @parent                = opts[:parent]
-
-      @linkage_always        = if opts[:linkage_always].nil?
-                                 # option not provided, use default
-                                 type == :belongs_to
-                               else
-                                 !!opts[:linkage_always]
-                               end
+      @group_name                    = opts[:group_name]
+      @polymorphic_child             = opts[:polymorphic_child]
+      @parent                        = opts[:parent]
+      @always_include_resource_ids   = opts[:always_include_resource_ids]
 
       if polymorphic_child?
         parent.resource.polymorphic << resource_class
@@ -120,8 +114,8 @@ module Graphiti
       !!@polymorphic_as
     end
 
-    def linkage_always?
-      !!@linkage_always
+    def always_include_resource_ids?
+      !!@always_include_resource_ids
     end
 
     def link?

--- a/lib/graphiti/sideload/belongs_to.rb
+++ b/lib/graphiti/sideload/belongs_to.rb
@@ -1,4 +1,9 @@
 class Graphiti::Sideload::BelongsTo < Graphiti::Sideload
+  def initialize(name, opts)
+    opts = { always_include_resource_ids: true }.merge(opts)
+    super(name, opts)
+  end
+
   def type
     :belongs_to
   end

--- a/lib/graphiti/util/serializer_relationships.rb
+++ b/lib/graphiti/util/serializer_relationships.rb
@@ -54,7 +54,7 @@ module Graphiti
 
           # include relationship links for belongs_to relationships
           # https://github.com/graphiti-api/graphiti/issues/167
-          linkage always: true if sideload_ref.type == :belongs_to
+          linkage always: sideload_ref.linkage_always?
 
           if link_ref
             if @proxy.query.links?

--- a/lib/graphiti/util/serializer_relationships.rb
+++ b/lib/graphiti/util/serializer_relationships.rb
@@ -49,9 +49,12 @@ module Graphiti
         data_proc_ref = data_proc
         self_ref = self
         validate_link! if eagerly_validate_links?
-
         proc do
           data { instance_eval(&data_proc_ref) }
+
+          # include relationship links for belongs_to relationships
+          # https://github.com/graphiti-api/graphiti/issues/167
+          linkage always: true if sideload_ref.type == :belongs_to
 
           if link_ref
             if @proxy.query.links?

--- a/lib/graphiti/util/serializer_relationships.rb
+++ b/lib/graphiti/util/serializer_relationships.rb
@@ -49,12 +49,13 @@ module Graphiti
         data_proc_ref = data_proc
         self_ref = self
         validate_link! if eagerly_validate_links?
+
         proc do
           data { instance_eval(&data_proc_ref) }
 
           # include relationship links for belongs_to relationships
           # https://github.com/graphiti-api/graphiti/issues/167
-          linkage always: sideload_ref.linkage_always?
+          linkage always: sideload_ref.always_include_resource_ids?
 
           if link_ref
             if @proxy.query.links?

--- a/spec/relationship_identifier_spec.rb
+++ b/spec/relationship_identifier_spec.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'relationship identifiers' do
+  include_context 'resource testing'
+
+  # let(:base_scope) { { type: :positions } }
+  let!(:employee) { PORO::Employee.create }
+  let!(:employee2) { PORO::Employee.create }
+  let!(:position1) do
+    PORO::Position.create employee_id: employee.id,
+                          department_id: department1.id
+  end
+  let!(:position2) do
+    PORO::Position.create employee_id: employee.id,
+                          department_id: department2.id
+  end
+  let!(:department1) { PORO::Department.create }
+  let!(:department2) { PORO::Department.create }
+  let!(:bio1) { PORO::Bio.create(employee_id: employee.id) }
+  let!(:bio2) { PORO::Bio.create(employee_id: employee.id) }
+  let!(:team1) do
+    PORO::Team.create team_memberships: [
+      PORO::TeamMembership.new(employee_id: employee.id, team_id: 1)
+    ]
+  end
+  let!(:team2) do
+    PORO::Team.create team_memberships: [
+      PORO::TeamMembership.new(employee_id: employee.id, team_id: 2)
+    ]
+  end
+
+  describe 'has_many' do
+    context 'with default' do
+      let(:resource) do
+        Class.new(PORO::TeamResource) do
+          def self.name
+            'PORO::TeamResource'
+          end
+
+          has_many :employees
+        end
+      end
+
+      before do
+        allow_any_instance_of(PORO::Team).to receive(:employees) { [employee, employee2] }
+        render
+      end
+
+      it 'does not include anything' do
+        expect do
+          included('employees')
+        end.to raise_error(GraphitiSpecHelpers::Errors::NoSideloads)
+      end
+
+      it 'specifies meta[:included] = false' do
+        jsonapi_data.each do |record|
+          expect(record.relationships['employees']['meta']['included']).to eq(false)
+        end
+      end
+
+      it 'does not includes relationship identifiers' do
+        jsonapi_data.each do |record|
+          data = record.relationships['employees']['data']
+          expect(data).to be_nil
+        end
+      end
+    end
+    context 'with include directive' do
+      let(:resource) do
+        Class.new(PORO::TeamResource) do
+          def self.name
+            'PORO::TeamResource'
+          end
+
+          has_many :employees do
+            scope do |employee_ids|
+              {
+                type: :employees,
+                conditions: { employee_id: employee_ids }
+              }
+            end
+          end
+        end
+      end
+
+      before do
+        params[:include] = 'employees'
+        allow_any_instance_of(PORO::Team).to receive(:employees) { [employee, employee2] }
+        render
+      end
+
+      it 'includes employees' do
+        expect(included('employees').map(&:id)).to eq([1, 2])
+      end
+
+      it 'includes relationship identifiers' do
+        jsonapi_data.each do |record|
+          data = record.relationships['employees']['data']
+          expect(data).to_not be_nil
+          expect(data.pluck(:type).uniq).to match_array(['employees'])
+          expect(data.pluck(:id).uniq).to match_array(%w[1 2])
+        end
+      end
+    end
+
+    context 'without include directive and always_include_resource_ids: true' do
+      let(:resource) do
+        Class.new(PORO::TeamResource) do
+          def self.name
+            'PORO::TeamResource'
+          end
+
+          has_many :employees, always_include_resource_ids: true do
+            scope do |employee_ids|
+              {
+                type: :employees,
+                conditions: { employee_id: employee_ids }
+              }
+            end
+          end
+        end
+      end
+
+      before do
+        allow_any_instance_of(PORO::Team).to receive(:employees) { [employee, employee2] }
+        render
+      end
+
+      it 'does not include anything' do
+        expect do
+          included('employees')
+        end.to raise_error(GraphitiSpecHelpers::Errors::NoSideloads)
+      end
+
+      it 'includes relationship identifiers' do
+        jsonapi_data.each do |record|
+          data = record.relationships['employees']['data']
+          expect(data).to_not be_nil
+          expect(data.pluck(:type).uniq).to match_array(['employees'])
+          expect(data.pluck(:id).uniq).to match_array(%w[1 2])
+        end
+      end
+    end
+  end
+
+  describe 'belongs_to' do
+    context 'with include directive' do
+      let(:resource) do
+        Class.new(PORO::PositionResource) do
+          def self.name
+            'PORO::PositionResource'
+          end
+
+          belongs_to :employee
+        end
+      end
+      before do
+        params[:include] = 'employee'
+        render
+      end
+
+      it 'works' do
+        expect(included('employees').map(&:id)).to eq([1])
+      end
+
+      it 'has relationship identifiers' do
+        jsonapi_data.each do |record|
+          data = record.relationships['employee']['data']
+
+          expect(data[:type]).to eq('employees')
+          expect(data[:id]).to eq('1')
+        end
+      end
+    end
+
+    context 'with defaults' do
+      let(:resource) do
+        Class.new(PORO::PositionResource) do
+          def self.name
+            'PORO::PositionResource'
+          end
+
+          belongs_to :employee
+        end
+      end
+
+      before do
+        allow_any_instance_of(PORO::Position).to receive(:employee) { employee }
+        render
+      end
+
+      it 'has relationship ids' do
+        jsonapi_data.each do |record|
+          data = record.relationships['employee']['data']
+
+          expect(data[:type]).to eq('employees')
+          expect(data[:id]).to eq('1')
+        end
+      end
+    end
+
+    context 'with always_include_resource_ids: false' do
+      let(:resource) do
+        Class.new(PORO::PositionResource) do
+          def self.name
+            'PORO::PositionResource'
+          end
+
+          belongs_to :employee, always_include_resource_ids: false do
+            scope do |employee_ids|
+              {
+                type: :employees,
+                conditions: { id: employee_ids }
+              }
+            end
+          end
+        end
+      end
+
+      before do
+        allow_any_instance_of(PORO::Position).to receive(:employee) { employee }
+        render
+      end
+
+      it 'has no relationship identifiers' do
+        jsonapi_data.each do |record|
+          data = record.relationships['employee']
+          expect(data.keys).to_not include('data')
+        end
+      end
+    end
+  end
+end

--- a/spec/sideloading_spec.rb
+++ b/spec/sideloading_spec.rb
@@ -215,36 +215,14 @@ RSpec.describe "sideloading" do
   end
 
   describe "has_many macro" do
-    before do
-      resource.class_eval do
-        has_many :positions do
-          scope do |employee_ids|
-            {
-              type: :positions,
-              conditions: {employee_id: employee_ids},
-            }
-          end
-        end
-      end
-      params[:include] = "positions"
-    end
-
-    it "works" do
-      render
-      expect(included("positions").map(&:id)).to eq([1, 2])
-    end
-
-    context "when custom foreign key given" do
+    context "with includes" do
       before do
-        PORO::DB.data[:positions][0] = {id: 1, e_id: 1}
-        PORO::DB.data[:positions][1] = {id: 2, e_id: 1}
-
         resource.class_eval do
-          has_many :positions, foreign_key: :e_id do
+          has_many :positions do
             scope do |employee_ids|
               {
                 type: :positions,
-                conditions: {e_id: employee_ids},
+                conditions: {employee_id: employee_ids},
               }
             end
           end
@@ -252,9 +230,113 @@ RSpec.describe "sideloading" do
         params[:include] = "positions"
       end
 
-      it "is used" do
+      it "works" do
         render
         expect(included("positions").map(&:id)).to eq([1, 2])
+      end
+
+      it "includes relationship linkage" do
+        render
+        jsonapi_data.each do |record|
+          data = record.relationships["positions"]["data"]
+          expect(data.pluck(:type).uniq).to match_array(["positions"])
+          expect(data.pluck(:id).uniq).to match_array(["1", "2"])
+        end
+      end
+
+      context "when custom foreign key given" do
+        before do
+          PORO::DB.data[:positions][0] = {id: 1, e_id: 1}
+          PORO::DB.data[:positions][1] = {id: 2, e_id: 1}
+
+          resource.class_eval do
+            has_many :positions, foreign_key: :e_id do
+              scope do |employee_ids|
+                {
+                  type: :positions,
+                  conditions: {e_id: employee_ids},
+                }
+              end
+            end
+          end
+          params[:include] = "positions"
+        end
+
+        it "is used" do
+          render
+          expect(included("positions").map(&:id)).to eq([1, 2])
+        end
+      end
+    end
+
+    context "without includes and default linkage" do
+      before do
+        resource.class_eval do
+          has_many :positions do
+            scope do |employee_ids|
+              {
+                type: :positions,
+                conditions: {employee_id: employee_ids},
+              }
+            end
+          end
+        end
+        render
+      end
+
+      it "does not include anything" do
+        expect {
+          included("positions")
+        }.to raise_error(GraphitiSpecHelpers::Errors::NoSideloads)
+      end
+
+      it "specifies meta[:included] = false" do
+        jsonapi_data.each do |record|
+          expect(record.relationships["positions"]["meta"]["included"]).to eq(false)
+        end
+      end
+
+      it "does not includes relationship linkage" do
+        jsonapi_data.each do |record|
+          data = record.relationships["positions"]["data"]
+          expect(data).to be_nil
+        end
+      end
+    end
+
+    context "without includes and linkage always: true" do
+      before do
+        resource.class_eval do
+          has_many :positions, linkage_always: true do
+            scope do |employee_ids|
+              {
+                type: :positions,
+                conditions: {employee_id: employee_ids},
+              }
+            end
+          end
+        end
+        render
+      end
+
+      it "does not include anything" do
+        expect {
+          included("positions")
+        }.to raise_error(GraphitiSpecHelpers::Errors::NoSideloads)
+      end
+
+      it "does not have meta[:included] = false" do
+        jsonapi_data.each do |record|
+          expect(record.relationships["positions"].dig("meta", "included")).to be_nil
+        end
+      end
+
+      it "includes relationship linkage" do
+        jsonapi_data.each do |record|
+          data = record.relationships["positions"]["data"]
+          expect(data.pluck(:type).uniq).to match_array(["positions"])
+          expect(data.pluck(:id).uniq).to match_array(["1", "2"])
+        end
       end
     end
   end
@@ -270,23 +352,92 @@ RSpec.describe "sideloading" do
 
     let(:base_scope) { {type: :positions} }
 
-    before do
-      resource.class_eval do
-        belongs_to :employee do
-          scope do |employee_ids|
-            {
-              type: :employees,
-              conditions: {id: employee_ids},
-            }
+    context "with includes" do
+      before do
+        resource.class_eval do
+          belongs_to :employee do
+            scope do |employee_ids|
+              {
+                type: :employees,
+                conditions: {id: employee_ids},
+              }
+            end
+          end
+        end
+        params[:include] = "employee"
+      end
+
+      it "works" do
+        render
+        expect(included("employees").map(&:id)).to eq([1])
+      end
+
+      it "has relationship linkage" do
+        render
+
+        jsonapi_data.each do |record|
+          data = record.relationships["employee"]["data"]
+
+          expect(data[:type]).to eq("employees")
+          expect(data[:id]).to eq("1")
+        end
+      end
+    end
+
+    context "with default linkage" do
+      before do
+        resource.class_eval do
+          belongs_to :employee do
+            scope do |employee_ids|
+              {
+                type: :employees,
+                conditions: {id: employee_ids},
+              }
+            end
           end
         end
       end
-      params[:include] = "employee"
+
+      it "has relationship linkage" do
+        render
+
+        jsonapi_data.each do |record|
+          data = record.relationships["employee"]["data"]
+
+          expect(data[:type]).to eq("employees")
+          expect(data[:id]).to eq("1")
+        end
+      end
     end
 
-    it "works" do
-      render
-      expect(included("employees").map(&:id)).to eq([1])
+    context "with linkage: false" do
+      before do
+        resource.class_eval do
+          belongs_to :employee, linkage_always: false do
+            scope do |employee_ids|
+              {
+                type: :employees,
+                conditions: {id: employee_ids},
+              }
+            end
+          end
+        end
+      end
+
+      it "works" do
+        render
+        expect(included("employees").map(&:id)).to eq([1])
+      end
+
+      it "has no relationship linkage" do
+        render
+
+        jsonapi_data.each do |record|
+          data = record.relationships["employee"]
+
+          expect(data.keys).to_not include('data')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This addresses issue #167

I'm unsure how to test this in the current suite. All the tests pass, but there's nothing explicitly testing this behavior. I tried modifying some tests in `sideloading_spec.rb`, but there's something with the way those PORO objects are working that don't trigger the `related_resources` like the tests in my rails app seem to do. Thought this would be a good starting point based off the discussion @wagenet and I had today, though. 