### PR TITLE
Disable the debugger if GRAPHITI_DEBUG is false

### DIFF
--- a/lib/graphiti/configuration.rb
+++ b/lib/graphiti/configuration.rb
@@ -43,7 +43,7 @@ module Graphiti
         end
 
         if (logger = ::Rails.logger)
-          self.debug = logger.level.zero?
+          self.debug = logger.level.zero? && self.debug
           Graphiti.logger = logger
         end
       end


### PR DESCRIPTION
I and my team spent quite some time trying to disable Graphiti's logger using the environment variable `GRAPHITI_DEBUG=false` and the configuration block:

```ruby
Graphiti.configure do |config|
  config.debug = false
end
```

But the logger was still printing debug statements because the debugger is forcefully turned on if the Rails debugger level is 0. This change allows the debugger to be turned off.

I didn't add any tests because the existing configuration test suite is stateful.

Complementary PR: https://github.com/graphiti-api/graphiti-rails/pull/37