### PR TITLE
Let the user disable the logger

### DIFF
--- a/lib/graphiti/configuration.rb
+++ b/lib/graphiti/configuration.rb
@@ -43,7 +43,7 @@ module Graphiti
         end
 
         if (logger = ::Rails.logger)
-          self.debug = logger.level.zero?
+          self.debug = logger.level.zero? && self.debug
           Graphiti.logger = logger
         end
       end


### PR DESCRIPTION
Allows the debugger to be permanently turned off with the configuration block (as per the documentation):

```ruby
Graphiti.configure do |config|
  config.debug = false
end
```

Complementary PR: https://github.com/graphiti-api/graphiti-rails/pull/38