### PR TITLE
[bugfix] Allow hashes to have custom filters

### DIFF
--- a/lib/graphiti/scoping/filter.rb
+++ b/lib/graphiti/scoping/filter.rb
@@ -128,7 +128,7 @@ module Graphiti
     end
 
     def parse_hash_value(filter, param_value, value, operator)
-      has_filter = filter.values[0][:operators][operator].present?
+      has_filter = resource.filters.dig(filter.keys.first, :operators, operator).present?
 
       if operator != :eq && !has_filter
         operator = :eq

--- a/lib/graphiti/scoping/filter.rb
+++ b/lib/graphiti/scoping/filter.rb
@@ -128,7 +128,9 @@ module Graphiti
     end
 
     def parse_hash_value(filter, param_value, value, operator)
-      if operator != :eq
+      has_filter = filter.values[0][:operators][operator].present?
+
+      if operator != :eq && !has_filter
         operator = :eq
         value = param_value
       end

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -45,6 +45,23 @@ RSpec.describe "filtering" do
       expect(records.map(&:id)).to eq([employee2.id])
     end
 
+    context "with a hash containing custom operators" do
+      before do
+        resource.filter :data, :hash do
+          match do |scope, value|
+            criteria = value[0].transform_keys(&:to_sym)
+            scope[:conditions][:id] = [1] if criteria[:title] == "freedom"
+            scope
+          end
+        end
+        params[:filter]= { data: { match: { title: "freedom" }.to_json } }
+      end
+
+      it "works" do
+        expect(records.map(&:id)).to eq([employee1.id])
+      end
+    end
+
     context "and the hash has multiple keys" do
       before do
         params[:filter] = {by_json: '{ "id": 2, "id2": 3 }'}


### PR DESCRIPTION
Resolves: #164 

### Description
Sometimes you want to perform other operations on a hash other an equals. Now you can :)

### Background
Previously, Graphiti always defaulted to the `eq` operator for hashes. This appears to have been for convenience sake so that when you do `filter[data]={ foo: bar}` it evaluated against an equals operation, rather than having to type `filter[data][eq]={ foo: bar }`. 

### Approach
The idea here is to only default the operator to `eq` if the current resource and filter combo do not have that operator defined. In an ideal world, we would probably want to never default...but that would break some backward compatibility. Maybe in a couple of minor versions forward? 🙏 