### PR TITLE
Features/relationship protection blocks

### DIFF
--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -26,8 +26,8 @@ module Graphiti
       @foreign_key                   = opts[:foreign_key]
       @type                          = opts[:type]
       @base_scope                    = opts[:base_scope]
-      @readable                      = opts[:readable]
-      @writable                      = opts[:writable]
+      @readable                      = evaluate_flag(opts[:readable])
+      @writable                      = evaluate_flag(opts[:writable])
       @as                            = opts[:as]
       @link                          = opts[:link]
       @single                        = opts[:single]
@@ -410,6 +410,21 @@ module Graphiti
 
     def namespace_for(klass)
       Util::Class.namespace_for(klass)
+    end
+
+    def evaluate_flag(flag)
+      return false if flag.blank?
+
+      case flag.class.name
+      when "Symbol"
+        resource.send(flag)
+      when "Proc"
+        flag.call
+      when "String"
+        resource.send(flag)
+      else
+        !!flag
+      end
     end
   end
 end

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -419,7 +419,7 @@ module Graphiti
       when "Symbol","String"
         resource.send(flag)
       when "Proc"
-        flag.call
+        self.resource.instance_exec(&flag)
       else
         !!flag
       end

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -416,12 +416,10 @@ module Graphiti
       return false if flag.blank?
 
       case flag.class.name
-      when "Symbol"
+      when "Symbol","String"
         resource.send(flag)
       when "Proc"
         flag.call
-      when "String"
-        resource.send(flag)
       else
         !!flag
       end

--- a/spec/sideload_spec.rb
+++ b/spec/sideload_spec.rb
@@ -51,6 +51,53 @@ RSpec.describe Graphiti::Sideload do
     end
   end
 
+  describe "reading and writing" do
+    context "with booleans" do
+      it "works" do
+        instance = Class.new(described_class).new(name, opts.merge(readable: true, writable: true))
+        expect(instance).to be_readable
+        expect(instance).to be_writable
+
+        instance = Class.new(described_class).new(name, opts.merge(readable: false, writable: false))
+        expect(instance).not_to be_readable
+        expect(instance).not_to be_writable
+      end
+    end
+
+    context "with symbols" do
+      let(:resource_class) do
+        Class.new(PORO::PositionResource) do
+          self.model = PORO::Position
+          def self.name
+            "PORO::PositionResource"
+          end
+
+          def user_can_read?
+            false
+          end
+
+          def user_can_write?
+            true
+          end
+        end
+      end
+
+      it "works" do
+        instance = Class.new(described_class).new(name, opts.merge(readable: :user_can_read?, writable: :user_can_write?))
+        expect(instance).not_to be_readable
+        expect(instance).to be_writable
+      end
+    end
+
+    context "with procs" do
+      it "works" do
+        instance = Class.new(described_class).new(name, opts.merge(readable: lambda{ false }, writable: lambda{ true }))
+        expect(instance).not_to be_readable
+        expect(instance).to be_writable
+      end
+    end
+  end
+
   describe "#primary_key" do
     it "defaults to id" do
       expect(instance.primary_key).to eq(:id)

--- a/spec/sideload_spec.rb
+++ b/spec/sideload_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Graphiti::Sideload do
       end
     end
 
-    context "with symbols" do
+    context "with symbols and stings" do
       let(:resource_class) do
         Class.new(PORO::PositionResource) do
           self.model = PORO::Position
@@ -82,8 +82,14 @@ RSpec.describe Graphiti::Sideload do
         end
       end
 
-      it "works" do
+      it "works with symbols" do
         instance = Class.new(described_class).new(name, opts.merge(readable: :user_can_read?, writable: :user_can_write?))
+        expect(instance).not_to be_readable
+        expect(instance).to be_writable
+      end
+
+      it "works with strings" do
+        instance = Class.new(described_class).new(name, opts.merge(readable: "user_can_read?", writable: "user_can_write?"))
         expect(instance).not_to be_readable
         expect(instance).to be_writable
       end

--- a/spec/sideload_spec.rb
+++ b/spec/sideload_spec.rb
@@ -96,8 +96,26 @@ RSpec.describe Graphiti::Sideload do
     end
 
     context "with procs" do
+      let(:resource_class) do
+        Class.new(PORO::PositionResource) do
+          self.model = PORO::Position
+          def self.name
+            "PORO::PositionResource"
+          end
+
+          def user_can_read?
+            false
+          end
+
+          def user_can_write?
+            true
+          end
+        end
+      end
+
       it "works" do
-        instance = Class.new(described_class).new(name, opts.merge(readable: lambda{ false }, writable: lambda{ true }))
+        options = opts.merge(readable: lambda { user_can_read? }, writable: lambda{ true })
+        instance = Class.new(described_class).new(name, options)
         expect(instance).not_to be_readable
         expect(instance).to be_writable
       end


### PR DESCRIPTION
Resolves: https://github.com/graphiti-api/graphiti/issues/143

### Background
Previously, when defining relationships on a resource it was only possible to define `readable` and `writable` as booleans. However, as permissions come into play this quickly becomes insufficient and requires a manual defining of the relationship via the block system. This could be a little nicer :)

### Approach
* Allow symbols to be passed to `readable` and `writable`. These will get evaluated as methods on the resource.
* Allow symbols to be passed to `readable` and `writable`. These will get evaluated as methods on the resource.
* Allow blocks to be passed to `readable` and `writable`. These will get evaluated without resource context.