### PR TITLE
Fix polymorphic sideload logic

### DIFF
--- a/lib/graphiti/version.rb
+++ b/lib/graphiti/version.rb
@@ -1,3 +1,3 @@
 module Graphiti
-  VERSION = "1.2.6"
+  VERSION = "1.2.7"
 end


### PR DESCRIPTION
If only certain sideloads had a relationship, this could have unexpected
behavior. This ensures everything loads as it should. Spec in followup.