### PR TITLE
Fix unnecessary queries

### DIFF
--- a/lib/graphiti/sideload/belongs_to.rb
+++ b/lib/graphiti/sideload/belongs_to.rb
@@ -1,6 +1,6 @@
 class Graphiti::Sideload::BelongsTo < Graphiti::Sideload
   def initialize(name, opts)
-    opts = { always_include_resource_ids: true }.merge(opts)
+    opts = { always_include_resource_ids: false }.merge(opts)
     super(name, opts)
   end
 

--- a/lib/graphiti/version.rb
+++ b/lib/graphiti/version.rb
@@ -1,3 +1,3 @@
 module Graphiti
-  VERSION = "1.2.7"
+  VERSION = "1.2.8"
 end

--- a/spec/relationship_identifier_spec.rb
+++ b/spec/relationship_identifier_spec.rb
@@ -191,7 +191,8 @@ RSpec.describe 'relationship identifiers' do
         render
       end
 
-      it 'has relationship ids' do
+      # Currently disabled as causes an N+1
+      xit 'has relationship ids' do
         jsonapi_data.each do |record|
           data = record.relationships['employee']['data']
 


### PR DESCRIPTION
PR https://github.com/graphiti-api/graphiti/pull/168 introduced N+1 by
default. This removes that as the default option, and we'll look into it
more in a future PR.