### PR TITLE
Clear Sideload resources after context block returns

### DIFF
--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -32,6 +32,10 @@ module Graphiti
     yield
   ensure
     self.context = prior
+
+    resources.each { |resource_class|
+      resource_class.sideloads.values.each(&:clear_resources)
+    }
   end
 
   def self.config

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -224,6 +224,7 @@ module Graphiti
       @parent_resource ||= parent_resource_class.new
     end
 
+    # See https://github.com/graphiti-api/graphiti/issues/186
     def clear_resources
       @resource = nil
       @parent_resource = nil

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -224,6 +224,11 @@ module Graphiti
       @parent_resource ||= parent_resource_class.new
     end
 
+    def clear_resources
+      @resource = nil
+      @parent_resource = nil
+    end
+
     def assign(parents, children)
       track_associated = type == :has_one
       associated = [] if track_associated

--- a/spec/sideloading_spec.rb
+++ b/spec/sideloading_spec.rb
@@ -1044,6 +1044,21 @@ RSpec.describe "sideloading" do
         render
       }.to_not raise_error
     end
+
+    describe "across requests" do
+      it "uses a different sideloaded resource" do
+        ctx = double(current_user: :admin)
+        sl1 = Graphiti.with_context ctx do
+          resource.all(params).query.sideloads.values[0].resource
+        end
+
+        sl2 = Graphiti.with_context ctx do
+          resource.all(params).query.sideloads.values[0].resource
+        end
+
+        expect(sl1).to_not be sl2
+      end
+    end
   end
 
   context "when a required filter on the sideloaded resource" do


### PR DESCRIPTION
This is a fairly straight-forward fix for https://github.com/graphiti-api/graphiti/issues/186 outlined in https://github.com/graphiti-api/graphiti/issues/186#issuecomment-546337841. I'm not sure if there are other transient objects that should be cleared at the same time but this passes the test.

This solution probably isn't the best since you can nest Graphiti contexts and the closing of an inner context will affect the outer context by this change.