### PR TITLE
Convert resource type to symbol

### DIFF
--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -22,6 +22,7 @@ module Graphiti
         end
 
         def type=(val)
+          val = val && val.to_sym
           if (val = super)
             serializer.type(val)
           end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -195,6 +195,18 @@ RSpec.describe Graphiti::Resource do
           expect(klass.type).to eq(:blahs)
         end
       end
+
+      context "when manually setting type as string" do
+        let(:klass) do
+          Class.new(app_resource) do
+            self.type = "blahs"
+          end
+        end
+
+        it "works" do
+          expect(klass.type).to eq(:blahs)
+        end
+      end
     end
 
     describe "a descendent of a non-abstract Resource" do


### PR DESCRIPTION
Coerce resource type to symbol under the hood to avoid types that do not match problems down the road.