### PR TITLE
Allow updates to process reserved keywords

### DIFF
--- a/lib/graphiti/resource/persistence.rb
+++ b/lib/graphiti/resource/persistence.rb
@@ -93,7 +93,7 @@ module Graphiti
 
         run_callbacks :persistence, :update, update_params, meta do
           run_callbacks :attributes, :update, update_params, meta do |params|
-            model_instance = self.class._find(params.merge(id: id)).data
+            model_instance = self.class._find(id: id).data
             call_with_meta(:assign_attributes, model_instance, params, meta)
             model_instance
           end


### PR DESCRIPTION
Params like 'page' would throw an error, even though they were in the
attributes payload. This is because we passed all params to the "find"
call preceding the update. I can't think of a reason we should pass all
parameters here, we only need the `id` - so let's pass only that and fix
the issue.