### PR TITLE
Provide resource hook to mutate scope after filters are applied.

### DIFF
--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -20,7 +20,7 @@ module Graphiti
       yield scope
     end
 
-    def after_filters(scope)
+    def after_filtering(scope)
       scope
     end
 

--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -20,6 +20,10 @@ module Graphiti
       yield scope
     end
 
+    def after_filters(scope)
+      scope
+    end
+
     def serializer_for(model)
       serializer
     end

--- a/lib/graphiti/scoping/filter.rb
+++ b/lib/graphiti/scoping/filter.rb
@@ -16,7 +16,7 @@ module Graphiti
         @scope = filter_scope(filter, operator, value)
       end
 
-      @scope
+      resource.after_filters(@scope)
     end
 
     private

--- a/lib/graphiti/scoping/filter.rb
+++ b/lib/graphiti/scoping/filter.rb
@@ -16,7 +16,7 @@ module Graphiti
         @scope = filter_scope(filter, operator, value)
       end
 
-      resource.after_filters(@scope)
+      resource.after_filtering(@scope)
     end
 
     private

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -1677,4 +1677,23 @@ RSpec.describe "filtering" do
       end
     end
   end
+
+  context "when calling #after_filters hook" do
+    before do
+      resource.class_eval do
+        def after_filters(scope)
+          scope[:conditions][:first_name][0].capitalize!
+          scope
+        end
+      end
+
+      resource.attribute :last_name, :string
+    end
+
+    it "allows mutations of the scope" do
+      params[:filter] = {first_name: "agatha"}
+
+      expect(records.map(&:id)).to eq([employee2.id])
+    end
+  end
 end

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -1678,10 +1678,10 @@ RSpec.describe "filtering" do
     end
   end
 
-  context "when calling #after_filters hook" do
+  context "when calling #after_filtering hook" do
     before do
       resource.class_eval do
-        def after_filters(scope)
+        def after_filtering(scope)
           scope[:conditions][:first_name][0].capitalize!
           scope
         end


### PR DESCRIPTION
In order to do scope manipulation only after all provided filters are applied adding a hook `#after_filtering(scope)`. The resulting scope will be used for sorting, pagination, and stats. This might be useful for doing a group by or some other one time query where the filtered scope is used as the sub query.