### PR TITLE
Excape `match` operations to prevent DoS queries

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -79,11 +79,30 @@ module Graphiti
         filter_string_suffix(scope, attribute, value, is_not: true)
       end
 
-      def filter_string_match(scope, attribute, value, is_not: false)
-        column = column_for(scope, attribute)
-        map = value.map { |v| "%#{v.downcase}%" }
-        clause = column.lower.matches_any(map)
-        is_not ? scope.where.not(clause) : scope.where(clause)
+      # Arel has different match escaping behavior before rails 5.
+      # Since rails 4.x does not expose methods to escape LIKE statements
+      # anyway, we just don't support proper LIKE escaping in those versions.
+      if ::ActiveRecord.version >= Gem::Version.new('5.0.0')
+        def filter_string_match(scope, attribute, value, is_not: false)
+          escape_char = '\\'
+          column = column_for(scope, attribute)
+          map = value.map do |v|
+            v = v.downcase
+            v = scope.sanitize_sql_like(v)
+            "%#{v}%"
+          end
+          clause = column.lower.matches_any(map, escape_char, true)
+          is_not ? scope.where.not(clause) : scope.where(clause)
+        end
+      else
+        def filter_string_match(scope, attribute, value, is_not: false)
+          column = column_for(scope, attribute)
+          map = value.map do |v|
+            "%#{v.downcase}%"
+          end
+          clause = column.lower.matches_any(map)
+          is_not ? scope.where.not(clause) : scope.where(clause)
+        end
       end
 
       def filter_string_not_match(scope, attribute, value)

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -263,6 +263,24 @@ if ENV["APPRAISAL_INITIALIZED"]
           it "executes case-insensitive match query" do
             expect(ids).to eq([author2.id, author3.id])
           end
+
+          if ::ActiveRecord.version >= Gem::Version.new("5.0")
+            context 'when match string includes % characters' do
+              let(:value) { {match: "ld%ca"} }
+
+              let!(:author_with_percent) do
+                Legacy::Author.create!(first_name: "Wild%card")
+              end
+
+              let!(:author_with_dash) do
+                Legacy::Author.create!(first_name: "Wild-card")
+              end
+
+              it "does not use the provided % as a wildcard character" do
+                expect(ids).to eq([author_with_percent.id])
+              end
+            end
+          end
         end
 
         context "!match" do


### PR DESCRIPTION
Previously when doing a `match` operation against an activerecord string
field, we passed down the string directly and surrounded it with `%` on
either side, allowing a substring match of the column.  There was
nothing preventing a client from including additional `%` wildcard
characters in their query string to add more advanced substring
matching. The problem with this is that if an attacker provides a few
dozen wildcard characters, the sql engine can very quickly run into
processing problems and cause a Denial of Service against the
database/application.

This commit takes advantage of activerecord and arel's sql escaping
behavior to make this safe, at the tradeoff of not being able to pass
additional wildcard characters as part of queries.  Note that rails 4.x
has fewer APIs for this behavior and they aren't all public. Because
that is now an unsupported version of rails, this PR simply keeps the
less safe older behavior when that version of activerecord is detected.