### PR TITLE
Bypass required filters on .find

### DIFF
--- a/lib/graphiti/resource/interface.rb
+++ b/lib/graphiti/resource/interface.rb
@@ -28,7 +28,10 @@ module Graphiti
           params[:filter][:id] = id if id
 
           runner = Runner.new(self, params)
-          runner.proxy(base_scope, single: true, raise_on_missing: true)
+          runner.proxy base_scope,
+            single: true,
+            raise_on_missing: true,
+            bypass_required_filters: true
         end
 
         def build(params, base_scope = nil)

--- a/lib/graphiti/runner.rb
+++ b/lib/graphiti/runner.rb
@@ -63,7 +63,8 @@ module Graphiti
         :after_resolve,
         :sideload,
         :parent,
-        :params
+        :params,
+        :bypass_required_filters
       scope = jsonapi_scope(base, scope_opts)
       ResourceProxy.new jsonapi_resource,
         scope,

--- a/lib/graphiti/scoping/filter.rb
+++ b/lib/graphiti/scoping/filter.rb
@@ -3,7 +3,7 @@ module Graphiti
     include Scoping::Filterable
 
     def apply
-      if missing_required_filters.any?
+      if missing_required_filters.any? && !@opts[:bypass_required_filters]
         raise Errors::RequiredFilter.new(resource, missing_required_filters)
       end
 

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -1702,6 +1702,19 @@ RSpec.describe "filtering" do
           records
         }.to raise_error(Graphiti::Errors::RequiredFilter)
       end
+
+      context 'because it came from .find' do
+        before do
+          resource.filter :id, :integer
+        end
+
+        it 'does not require the filter' do
+          expect {
+            proxy = resource.find(filter: { id: employee2.id })
+            expect(proxy.data.id).to eq(employee2.id)
+          }.to_not raise_error
+        end
+      end
     end
   end
 


### PR DESCRIPTION
If there's a required filter, we should only require it when calling
`.all` and not `.find` - because there's no filtering to do here, we
already have the ID. Any auth would already be done via `base_scope`.

The other thing special about `.find` is we should raise an error when a
record is missing so we can render a 404. This follows that same
pattern, passing a special flag for this use case.