### PR TITLE
Fix nested resource lookup by type in update requests

### DIFF
--- a/lib/graphiti/resource/polymorphism.rb
+++ b/lib/graphiti/resource/polymorphism.rb
@@ -58,7 +58,7 @@ module Graphiti
         end
 
         def resource_for_type(type)
-          resource = children.find { |c| c.type == type }
+          resource = children.find { |c| c.type.to_s == type.to_s }
           if resource.nil?
             raise Errors::PolymorphicResourceChildNotFound.new(self, type: type)
           else

--- a/spec/request_validator_spec.rb
+++ b/spec/request_validator_spec.rb
@@ -175,6 +175,20 @@ RSpec.describe Graphiti::RequestValidator do
 
           expect(instance.errors).to be_blank
         end
+
+        context "when updating" do
+          before do
+            payload["action"] = "update"
+            payload[:data][:id] = 1
+            payload[:filter] = { id: 1 }
+          end
+
+          it "accepts the child type" do
+            validate
+
+            expect(instance.errors).to be_blank
+          end
+        end
       end
     end
 


### PR DESCRIPTION
I noticed that `UpdateValidator` compares type from payload with type from resource by typecasting the latter to string. However for nested resource is being looked up by `Polymorphism.resource_for_type` which expects type to be a symbol. This doesn't work when performed with a user-supplied string type from `UpdateValidator`.

In this PR you'll find both a fix and a test that fails without the fix.