### PR TITLE
Ensure multiple filters work with legacy syntax

### DIFF
--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -126,10 +126,13 @@ module Graphiti
             name = name.to_sym
 
             if legacy_nested?(name)
-              filter_name = value.keys.first.to_sym
-              filter_value = value.values.first
-              if @resource.get_attr!(filter_name, :filterable, request: true)
-                hash[filter_name] = filter_value
+              value.keys.each do |key|
+                filter_name = key.to_sym
+                filter_value = value[key]
+
+                if @resource.get_attr!(filter_name, :filterable, request: true)
+                  hash[filter_name] = filter_value
+                end
               end
             elsif nested?(name)
               name = name.to_s.split(".").last.to_sym

--- a/lib/graphiti/version.rb
+++ b/lib/graphiti/version.rb
@@ -1,3 +1,3 @@
 module Graphiti
-  VERSION = "1.2.14"
+  VERSION = "1.2.15"
 end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -265,6 +265,17 @@ RSpec.describe Graphiti::Query do
           expect(hash).to eq(expected)
         end
 
+        context 'with multiple filters' do
+          before do
+            params[:filter][:positions][:id] = 4
+          end
+
+          it 'keeps both filters' do
+            expect(hash[:include][:positions][:filter])
+              .to eq(title: 'bar', id: 4)
+          end
+        end
+
         context "with stringified keys" do
           before do
             params.deep_stringify_keys!


### PR DESCRIPTION
We should be using the graphiti dot syntax (e.g. `positions.active`)
instead of the legacy (e.g. `positions[active]`). But let's make sure to
support the legacy syntax for old users upgrading.