### PR TITLE
Allow resource level links to be defined

### DIFF
--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -148,5 +148,16 @@ module Graphiti
       end
       response
     end
+
+    def links?
+      self.class.links.any?
+    end
+
+    def links(model)
+      self.class.links.inject({}) do |memo, (name, blk)| 
+        memo[name] = instance_exec(model, &blk)
+        memo
+      end
+    end
   end
 end

--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -198,6 +198,7 @@ module Graphiti
               extra_attributes: {},
               sideloads: {},
               callbacks: {},
+              links: {},
             }
         end
 
@@ -235,6 +236,10 @@ module Graphiti
 
         def default_filters
           config[:default_filters]
+        end
+
+        def links
+          config[:links]
         end
       end
 

--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -146,6 +146,10 @@ module Graphiti
           end
         end
 
+        def link(name, &blk)
+          config[:links][name.to_sym] = blk
+        end
+
         def all_attributes
           attributes.merge(extra_attributes)
         end

--- a/lib/graphiti/serializer.rb
+++ b/lib/graphiti/serializer.rb
@@ -25,7 +25,7 @@ module Graphiti
     def as_jsonapi(*)
       super.tap do |hash|
         strip_relationships!(hash) if strip_relationships?
-        hash[:links] = @resource.links(@object) if @resource.links?
+        add_links!(hash)
       end
     end
 
@@ -49,6 +49,12 @@ module Graphiti
     end
 
     private
+
+    def add_links!(hash)
+      return unless @resource.respond_to?(:links?)
+
+      hash[:links] = @resource.links(@object).compact if @resource.links?
+    end
 
     def strip_relationships!(hash)
       hash[:relationships]&.select! do |name, payload|

--- a/lib/graphiti/serializer.rb
+++ b/lib/graphiti/serializer.rb
@@ -25,6 +25,7 @@ module Graphiti
     def as_jsonapi(*)
       super.tap do |hash|
         strip_relationships!(hash) if strip_relationships?
+        hash[:links] = @resource.links(@object) if @resource.links?
       end
     end
 

--- a/lib/graphiti/serializer.rb
+++ b/lib/graphiti/serializer.rb
@@ -53,7 +53,7 @@ module Graphiti
     def add_links!(hash)
       return unless @resource.respond_to?(:links?)
 
-      hash[:links] = @resource.links(@object).compact if @resource.links?
+      hash[:links] = @resource.links(@object) if @resource.links?
     end
 
     def strip_relationships!(hash)

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -1405,9 +1405,10 @@ RSpec.describe "serialization" do
         resource.link :test_link do |model| nil end
       end
 
-      specify "are omitted" do
+      specify "are still included" do
         render
-        expect(json["data"][0]["links"]).not_to have_key("test_link")
+        expect(json["data"][0]["links"]).to have_key("test_link")
+        expect(json["data"][0]["links"]["test_link"]).to eq(nil)
       end
     end
   end

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -860,7 +860,7 @@ RSpec.describe "serialization" do
     end
   end
 
-  describe "links" do
+  describe "relationship links" do
     let!(:employee) { PORO::Employee.create }
 
     def positions
@@ -1374,6 +1374,40 @@ RSpec.describe "serialization" do
             end
           end
         end
+      end
+    end
+  end
+
+  describe "resource-level links" do
+    let!(:employee) { PORO::Employee.create(id: 123) }
+    context "by default" do
+      specify "are not emitted" do
+        render
+
+        expect(json["data"][0]).not_to have_key("links")
+      end
+    end
+
+    context "when specified" do
+      before do
+        resource.link :test_link do |model| "#{self.endpoint[:url]}/#{model.id}" end
+      end
+
+      it "links correctly" do
+        render
+        expect(json["data"][0]["links"]["test_link"])
+          .to eq("/poro/employees/123")
+      end
+    end
+
+    context "nil links" do
+      before do
+        resource.link :test_link do |model| nil end
+      end
+
+      specify "are omitted" do
+        render
+        expect(json["data"][0]["links"]).not_to have_key("test_link")
       end
     end
   end


### PR DESCRIPTION


Graphiti supports links at a relationship level and at the top-level of the
jsonapi document.

Relationship level links are mainly to support lazy loading, and top level links
are used solely for pagination.

This commit adds support for defining links at the resource level.

These links could be used to provide the URL to the resource, or alternative
representation of the resource, or even actions to perform against the resource.
```
{
  "data": {
    "id": 1,
    "type": "tests",
    "attributes": {},
    "relationships": {},
    "links": {
      "self": "http://test.com/api/v1/tests/1"
    }
  }
}
```
To define a link on a resource:
```
link :self do |model|
  url_for([:api, :v1, model])
end
```