### PR TITLE
Fixed selecting serializer for deeply inherited resources

### DIFF
--- a/lib/graphiti/resource/polymorphism.rb
+++ b/lib/graphiti/resource/polymorphism.rb
@@ -67,7 +67,8 @@ module Graphiti
         end
 
         def resource_for_model(model)
-          resource = children.find { |c| model.is_a?(c.model) }
+          resource = children.find { |c| model.class == c.model } ||
+            children.find { |c| model.is_a?(c.model) }
           if resource.nil?
             raise Errors::PolymorphicResourceChildNotFound.new(self, model: model)
           else

--- a/spec/fixtures/poro.rb
+++ b/spec/fixtures/poro.rb
@@ -36,6 +36,7 @@ module PORO
           teams: PORO::Team,
           paypals: PORO::Paypal,
           visas: PORO::Visa,
+          gold_visas: PORO::GoldVisa,
           mastercards: PORO::Mastercard,
           visa_rewards: PORO::VisaReward,
           books: PORO::Book,
@@ -241,6 +242,9 @@ module PORO
     end
   end
 
+  class GoldVisa < Visa
+  end
+
   class Mastercard < CreditCard
   end
 
@@ -397,7 +401,7 @@ module PORO
   end
 
   class CreditCardResource < ApplicationResource
-    self.polymorphic = %w[PORO::VisaResource PORO::MastercardResource]
+    self.polymorphic = %w[PORO::VisaResource PORO::GoldVisaResource PORO::MastercardResource]
 
     def base_scope
       {type: [:visas, :mastercards]}
@@ -420,6 +424,9 @@ module PORO
     end
 
     has_many :visa_rewards
+  end
+
+  class GoldVisaResource < VisaResource
   end
 
   class MastercardResource < CreditCardResource

--- a/spec/polymorphic_resource_spec.rb
+++ b/spec/polymorphic_resource_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe "polymorphic resources" do
     it "returns the serializer of the child resource associated to the given model" do
       expect(instance.serializer_for(PORO::Visa.new))
         .to eq(PORO::VisaResource.serializer)
+      expect(instance.serializer_for(PORO::GoldVisa.new))
+        .to eq(PORO::GoldVisaResource.serializer)
     end
 
     context "when a polymorphic child" do

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -703,7 +703,7 @@ RSpec.describe Graphiti::Schema do
       it "generates a polymorphic schema for the resource" do
         expect(schema[:resources][0][:polymorphic]).to eq(true)
         expect(schema[:resources][0][:children])
-          .to eq(["PORO::VisaResource", "PORO::MastercardResource"])
+          .to eq(["PORO::VisaResource", "PORO::GoldVisaResource", "PORO::MastercardResource"])
       end
     end
 


### PR DESCRIPTION
For models `A`, `B` and `C`, where `C` inherits from `B` and `B` inherits from `A` graphiti selected a `BResource` serializer when serializing `C` model records when it should have selected a `CResource`.

This happened because `resource_for_model` method in `polymorhphism.rb` resource class was matched with the model by comparing model class using `is_a?` method which returns `true` when the compared class it's either the class itself or is anywhere in its inheritance chain.

I've changed this comparison to using `==` but also kept the original comparison as a fallback for when nothing is matched using the new method - so that it doesn't break for users that depended on the comparison working as it used to.

I hope that adding a new class to PORO (`PORO::GoldVisa` and a resource for it) isn't an overkill.