### PR TITLE
Include more information in RecordNotFound errors.

### DIFF
--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -722,6 +722,21 @@ module Graphiti
     end
 
     class RecordNotFound < Base
+      def initialize(resource = nil, id = nil, path = nil)
+        @resource = resource
+        @id = id
+        @path = path
+      end
+
+      def message
+        if !@resource.nil? && !@id.nil?
+          "The referenced resource '#{@resource}' with id '#{@id}' could not be found.".tap do |msg|
+            msg << " Referenced at '#{@path}'" unless @path.nil?
+          end
+        else
+          "Specified Record Not Found"
+        end
+      end
     end
 
     class RequiredFilter < Base

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -2330,6 +2330,33 @@ RSpec.describe "persistence" do
             .to eq(["Description can't be blank"])
         end
       end
+
+      context "linking to an non-existing related record" do
+        let(:payload) do
+          {
+            data: {
+              type: "employees",
+              relationships: {
+                classification: {
+                  data: {
+                    type: "classifications",
+                    'id': "123"
+                  }
+                }
+              }
+            }
+          }
+        end
+
+        it "responds correctly" do
+          employee = klass.build(payload)
+          expect { employee.save }.to raise_error(
+            Graphiti::Errors::RecordNotFound,
+            "The referenced resource 'classification' with id '123' could not be found. " \
+            "Referenced at 'relationships/classifications'"
+          )
+        end
+      end
     end
 
     describe "has_one" do


### PR DESCRIPTION
When supplying a relationship to an existing resource, if the record cannot
be found then supply the resource name, id and relative json path in the
`Graphiti::Errors::NotFound` exception raised.