### PR TITLE
Make context accessible when customizing relationship params

### DIFF
--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -197,7 +197,7 @@ module Graphiti
 
       with_error_handling Errors::SideloadParamsError do
         params = load_params(parents, query)
-        params_proc&.call(params, parents)
+        params_proc&.call(params, parents, context)
         return [] if blank_query?(params)
         opts = load_options(parents, query)
         opts[:sideload] = self
@@ -433,6 +433,10 @@ module Graphiti
       else
         !!flag
       end
+    end
+
+    def context
+      Graphiti.context[:object]
     end
   end
 end

--- a/lib/graphiti/util/link.rb
+++ b/lib/graphiti/util/link.rb
@@ -63,7 +63,7 @@ module Graphiti
             params[:filter] = @sideload.base_filter([@model])
           end
 
-          @sideload.params_proc&.call(params, [@model])
+          @sideload.params_proc&.call(params, [@model], context)
         end
       end
 
@@ -74,6 +74,10 @@ module Graphiti
           path = "#{path}/#{@model.send(@sideload.foreign_key)}"
         end
         path
+      end
+
+      def context
+        Graphiti.context[:object]
       end
     end
   end

--- a/spec/sideload_spec.rb
+++ b/spec/sideload_spec.rb
@@ -566,16 +566,16 @@ RSpec.describe Graphiti::Sideload do
 
   describe ".params" do
     before do
-      instance.class.params do |hash, parents, query|
+      instance.class.params do |hash, parents, context|
         hash[:parents] = parents
-        hash[:query] = query
+        hash[:context] = context
       end
     end
 
     it "sets params proc" do
-      hash, parents, query = {}, [double("parent")], double("query")
-      instance.params_proc.call(hash, parents, query)
-      expect(hash).to eq(parents: parents, query: query)
+      hash, parents, context = {}, [double("parent")], double("context")
+      instance.params_proc.call(hash, parents, context)
+      expect(hash).to eq(parents: parents, context: context)
     end
   end
 
@@ -655,19 +655,25 @@ RSpec.describe Graphiti::Sideload do
 
     context "when params customization" do
       before do
-        instance.class.params do |hash, parents|
+        instance.class.params do |hash, parents, context|
           hash[:a] = parents
+          hash[:b] = context.current_user
         end
       end
 
       it "is respected" do
+        current_user = double
         expected = {
           foo: "bar",
-          a: parents
+          a: parents,
+          b: current_user
         }
         expect(resource_class).to receive(:_all)
           .with(expected, anything, {type: :positions})
-        instance.load(parents, query, nil)
+
+        Graphiti.with_context(OpenStruct.new(current_user: current_user)) do
+          instance.load(parents, query, nil)
+        end
       end
     end
 


### PR DESCRIPTION
`context` can be useful when customizing params in a relationship. This makes it accessible in the `params` block by adding it as the third block variable:

```rb
class PostResource < ApplicationResource
  has_many :comments do
    params do |hash, _posts, context|
      hash[:filter] = { locale: context.locale }
    end
  end
end
```

The current workaround is to directly reference `Graphiti.context[:object]` within the block, which is less desirable because that private API could change.