### PR TITLE
Ws/min 2309 disable links on demand through url query

### DIFF
--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -24,6 +24,8 @@ module Graphiti
 
     def links?
       return false if [:json, :xml, "json", "xml"].include?(params[:format])
+      return false if [false, "false"].include?(@params[:links])
+
       if Graphiti.config.links_on_demand
         [true, "true"].include?(@params[:links])
       else

--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -34,6 +34,8 @@ module Graphiti
     end
 
     def pagination_links?
+      return false if [false, "false"].include?(@params[:pagination_links])
+
       if Graphiti.config.pagination_links_on_demand
         [true, "true"].include?(@params[:pagination_links])
       else

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -939,7 +939,7 @@ RSpec.describe Graphiti::Query do
 
         context "as boolean" do
           before do
-            params[:links] = "true"
+            params[:links] = true
           end
 
           it { is_expected.to eq(true) }

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -917,6 +917,22 @@ RSpec.describe Graphiti::Query do
       it { is_expected.to eq(false) }
     end
 
+    context "when requested as string 'false'" do
+      before do
+        params[:links] = "false"
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when requested as boolean false" do
+      before do
+        params[:links] = false
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
     context "when links_on_demand" do
       around do |e|
         original = Graphiti.config.links_on_demand
@@ -929,7 +945,7 @@ RSpec.describe Graphiti::Query do
       end
 
       context "and requested" do
-        context "as string" do
+        context "as string 'true'" do
           before do
             params[:links] = "true"
           end
@@ -937,7 +953,7 @@ RSpec.describe Graphiti::Query do
           it { is_expected.to eq(true) }
         end
 
-        context "as boolean" do
+        context "as boolean true" do
           before do
             params[:links] = true
           end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -896,6 +896,26 @@ RSpec.describe Graphiti::Query do
     end
   end
 
+  describe "#pagination_links?" do
+    subject { instance.pagination_links? }
+
+    context "when requested as string 'false'" do
+      before do
+        params[:pagination_links] = "false"
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when requested as boolean false" do
+      before do
+        params[:pagination_links] = false
+      end
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe "#links?" do
     subject { instance.links? }
 


### PR DESCRIPTION
Pagination links have to be processed and they perform `count` queries. We found out that removing these pagination links greatly improved the performance of our system. Mostly because it is very expensive to do counts on certain tables.

This change allows the API clients to remove the links and pagination links with a query parameter:

```json
api.example.com/resource?links=false&pagination_links=false
```