### PR TITLE
Avoid deleting id from attributes

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -273,8 +273,8 @@ module Graphiti
 
       # (see Adapters::Abstract#update)
       def update(model_class, update_params)
-        instance = model_class.find(update_params.delete(:id))
-        instance.update_attributes(update_params)
+        instance = model_class.find(update_params.only(:id))
+        instance.update_attributes(update_params.except(:id))
         instance
       end
 

--- a/lib/graphiti/resource/persistence.rb
+++ b/lib/graphiti/resource/persistence.rb
@@ -89,7 +89,8 @@ module Graphiti
 
       def update(update_params, meta = nil)
         model_instance = nil
-        id = update_params.delete(:id)
+        id = update_params[:id]
+        update_params = update_params.except(:id)
 
         run_callbacks :persistence, :update, update_params, meta do
           run_callbacks :attributes, :update, update_params, meta do |params|

--- a/lib/graphiti/resource/remote.rb
+++ b/lib/graphiti/resource/remote.rb
@@ -19,7 +19,7 @@ module Graphiti
       end
 
       def save(model, meta)
-        if meta[:attributes] == {} && meta[:method] == :update
+        if meta[:attributes].except(:id) == {} && meta[:method] == :update
           model
         else
           raise Errors::RemoteWrite.new(self.class)


### PR DESCRIPTION
This can have side effects when sideposting a has_many and associating
multiple entities to the same pre-existing third level. Test coming,
patching now to fix pressing issue.