### PR TITLE
Fix included extra fields

### DIFF
--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -47,7 +47,11 @@ module Graphiti
         h[:filter] = filters
         h[:sort] = sorts
         h[:page] = pagination
-        unless association?
+        if association?
+          h[:extra_fields] = {
+             @resource.class.type => extra_fields[@resource.class.type]
+           } if extra_fields.key?(@resource.class.type)
+        else
           h[:fields] = fields
           h[:extra_fields] = extra_fields
         end

--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -49,9 +49,7 @@ module Graphiti
         h[:page] = pagination
         if association?
           resource_type = @resource.class.type
-          h[:extra_fields] = {
-             resource_type => extra_fields[resource_type]
-           } if extra_fields.key?(resource_type)
+          h[:extra_fields] = {resource_type => extra_fields[resource_type]} if extra_fields.key?(resource_type)
         else
           h[:fields] = fields
           h[:extra_fields] = extra_fields

--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -44,16 +44,16 @@ module Graphiti
 
     def hash
       @hash ||= {}.tap do |h|
-        h[:filter] = filters unless filters.empty?
-        h[:sort] = sorts unless sorts.empty?
-        h[:page] = pagination unless pagination.empty?
+        h[:filter] = filters
+        h[:sort] = sorts
+        h[:page] = pagination
         unless association?
-          h[:fields] = fields unless fields.empty?
-          h[:extra_fields] = extra_fields unless extra_fields.empty?
+          h[:fields] = fields
+          h[:extra_fields] = extra_fields
         end
-        h[:stats] = stats unless stats.empty?
-        h[:include] = sideload_hash unless sideload_hash.empty?
-      end
+        h[:stats] = stats
+        h[:include] = sideload_hash
+      end.reject { |_, value| value.empty? }
     end
 
     def zero_results?

--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -48,9 +48,10 @@ module Graphiti
         h[:sort] = sorts
         h[:page] = pagination
         if association?
+          resource_type = @resource.class.type
           h[:extra_fields] = {
-             @resource.class.type => extra_fields[@resource.class.type]
-           } if extra_fields.key?(@resource.class.type)
+             resource_type => extra_fields[resource_type]
+           } if extra_fields.key?(resource_type)
         else
           h[:fields] = fields
           h[:extra_fields] = extra_fields

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -747,7 +747,7 @@ RSpec.describe Graphiti::Query do
                 extra_fields: {positions: [:baz]},
                 include: {
                   department: {
-                    extra_fields: {departments: [:bax] }
+                    extra_fields: {departments: [:bax]}
                   }
                 }
               }

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -744,8 +744,11 @@ RSpec.describe Graphiti::Query do
             },
             include: {
               positions: {
+                extra_fields: {positions: [:baz]},
                 include: {
-                  department: {}
+                  department: {
+                    extra_fields: {departments: [:bax] }
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Why?
This is an attempt to resolve #229 by including the `extra_attributes` in an association query that are relevant to the resource. This change causes the `on_extra_attributes` hooks to fire for the associated resources, which is what we need to happen.

I'm mostly unfamiliar with this project's code, and I'm not sure this is the best approach. While this fixes the problem for us, I would like feedback on a strategy for writing a better test that captures the desired behavior: When `extra_attributes` are requests for a side-loaded, associated resource, the `on_extra_attributue` hooks are fired for the associated resource.