### PR TITLE
Use Query#params in pagination links instead of Query#hash.

### DIFF
--- a/lib/graphiti/delegates/pagination.rb
+++ b/lib/graphiti/delegates/pagination.rb
@@ -20,13 +20,17 @@ module Graphiti
 
       private
 
+      def pagination_params
+        @pagination_params ||= @proxy.query.params.reject { |k, _| [:action, :controller, :format].include?(k) }
+      end
+
       def pagination_link(page)
         return nil unless @proxy.resource.endpoint
 
         uri = URI(@proxy.resource.endpoint[:url].to_s)
 
         # Overwrite the pagination query params with the desired page
-        uri.query = @proxy.query.params.merge({
+        uri.query = pagination_params.merge({
           page: {
             number: page,
             size: page_size

--- a/lib/graphiti/delegates/pagination.rb
+++ b/lib/graphiti/delegates/pagination.rb
@@ -21,7 +21,7 @@ module Graphiti
       private
 
       def pagination_params
-        @pagination_params ||= @proxy.query.params.reject { |k, _| [:action, :controller, :format].include?(k) }
+        @pagination_params ||= @proxy.query.params.reject { |key, _| [:action, :controller, :format].include?(key) }
       end
 
       def pagination_link(page)

--- a/lib/graphiti/delegates/pagination.rb
+++ b/lib/graphiti/delegates/pagination.rb
@@ -26,7 +26,7 @@ module Graphiti
         uri = URI(@proxy.resource.endpoint[:url].to_s)
 
         # Overwrite the pagination query params with the desired page
-        uri.query = @proxy.query.hash.merge({
+        uri.query = @proxy.query.params.merge({
           page: {
             number: page,
             size: page_size

--- a/spec/delegates/pagination_spec.rb
+++ b/spec/delegates/pagination_spec.rb
@@ -59,11 +59,24 @@ RSpec.describe Graphiti::Delegates::Pagination do
         {include: "bar,bazzes", filter: {"bazzes.deprecated" => "foo"}}
       }
 
-      it "is preserved correctly" do
+      it "preserves include directive and filters on relationships" do
         query = URI.decode_www_form(URI(subject[:first]).query).to_h
         expect(query["include"]).to include("bar")
         expect(query["include"]).to include("bazzes")
         expect(query["filter[bazzes.deprecated]"]).to eq("foo")
+      end
+    end
+
+    context "with rails parameters" do
+      let(:params) {
+        {controller: "foos", action: "index", format: "jsonapi"}
+      }
+
+      it "removes them" do
+        page_links = subject.values
+        expect(page_links).to all(satisfy { |v| v["controller=foos"].nil? })
+        expect(page_links).to all(satisfy { |v| v["action=index"].nil? })
+        expect(page_links).to all(satisfy { |v| v["format=jsonapi"].nil? })
       end
     end
   end

--- a/spec/delegates/pagination_spec.rb
+++ b/spec/delegates/pagination_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe Graphiti::Delegates::Pagination do
         expect(subject[:first]).to eq(pagination_link(1, size: Graphiti::Scoping::Paginate::DEFAULT_PAGE_SIZE))
       end
     end
+
+    context "with included relationship" do
+      let(:params) {
+        {include: "bar,bazzes", filter: {"bazzes.deprecated" => "foo"}}
+      }
+
+      it "is preserved correctly" do
+        query = URI.decode_www_form(URI(subject[:first]).query).to_h
+        expect(query["include"]).to include("bar")
+        expect(query["include"]).to include("bazzes")
+        expect(query["filter[bazzes.deprecated]"]).to eq("foo")
+      end
+    end
   end
 
   def pagination_link(number, size: current_per_page)


### PR DESCRIPTION
## Why?
Using `Query#hash` doesn't correctly render links with an include directive and filtering included relationships. Passing the valid parameters received on the original request seems like ok approach.