### PR TITLE
Fix conditional rendering of an extra_attribute (:readable)

### DIFF
--- a/lib/graphiti/extensions/extra_attribute.rb
+++ b/lib/graphiti/extensions/extra_attribute.rb
@@ -43,7 +43,7 @@ module Graphiti
         def extra_attribute(name, options = {}, &blk)
           allow_field = proc {
             if options[:if]
-              next false unless instance_eval(&options[:if])
+              next false unless instance_exec(&options[:if])
             end
 
             @extra_fields &&


### PR DESCRIPTION
Both `attribute` and `extra_attribute` methods accept `:readable` option allowing to control rendering of an attribute when a condition is met. 

The behavior is not the same for them though - for `attribute` guard is called via `instance_exec` https://github.com/jsonapi-rb/jsonapi-serializable/blob/v0.3.1/lib/jsonapi/serializable/resource/conditional_fields.rb#L117 while for `extra_attribute` it's called via `instance_eval` https://github.com/graphiti-api/graphiti/blob/v1.2.19/lib/graphiti/extensions/extra_attribute.rb#L46

The latter causes:
```
ArgumentError:
  wrong number of arguments (given 1, expected 0)
# ./lib/graphiti/util/serializer_attributes.rb:59:in `block in guard'
# ./lib/graphiti/extensions/extra_attribute.rb:46:in `instance_eval'
# ./lib/graphiti/extensions/extra_attribute.rb:46:in `block in extra_attribute'
```
(see regression spec)