### PR TITLE
Sideload macro bug

### DIFF
--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -33,7 +33,7 @@ module Graphiti
     resources.each do |resource_class|
       resource_class.sideloads.values.each do |sideload|
         flag = sideload.instance_variable_get(:@readable)
-        next if evaluated = sideload.send(:evaluate_flag, flag)
+        next if (evaluated = sideload.send(:evaluate_flag, flag))
 
         resource_class.serializer.relationship(sideload.name, if: -> { evaluated })
       end

--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -29,6 +29,14 @@ module Graphiti
   def self.with_context(obj, namespace = nil)
     prior = context
     self.context = {object: obj, namespace: namespace}
+    # conditional reads per request
+    resources.each do |resource_class|
+      resource_class.sideloads.values.each do |sideload|
+        flag = sideload.instance_variable_get(:@readable)
+        evaluated = sideload.send(:evaluate_flag, flag)
+        resource_class.serializer.relationship(sideload.name, if: -> { evaluated })
+      end
+    end
     yield
   ensure
     self.context = prior

--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -33,7 +33,8 @@ module Graphiti
     resources.each do |resource_class|
       resource_class.sideloads.values.each do |sideload|
         flag = sideload.instance_variable_get(:@readable)
-        evaluated = sideload.send(:evaluate_flag, flag)
+        next if evaluated = sideload.send(:evaluate_flag, flag)
+
         resource_class.serializer.relationship(sideload.name, if: -> { evaluated })
       end
     end

--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -180,7 +180,7 @@ module Graphiti
             options[name] ||= send(:"relationships_#{name}_by_default")
           end
         end
-        private :attribute_option
+        private :relationship_option
       end
     end
   end

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -99,7 +99,7 @@ module Graphiti
     end
 
     def readable?
-      !!@readable
+      !!evaluate_flag(@readable)
     end
 
     def writable?

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -27,7 +27,7 @@ module Graphiti
       @type = opts[:type]
       @base_scope = opts[:base_scope]
       @readable = opts[:readable]
-      @writable = opts[:writable]
+      @writable = evaluate_flag(opts[:writable])
       @as = opts[:as]
       @link = opts[:link]
       @single = opts[:single]

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -26,8 +26,8 @@ module Graphiti
       @foreign_key = opts[:foreign_key]
       @type = opts[:type]
       @base_scope = opts[:base_scope]
-      @readable = evaluate_flag(opts[:readable])
-      @writable = evaluate_flag(opts[:writable])
+      @readable = opts[:readable]
+      @writable = opts[:writable]
       @as = opts[:as]
       @link = opts[:link]
       @single = opts[:single]

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -721,8 +721,14 @@ RSpec.describe "serialization" do
           end
 
           def admin?
-            true
+            !!context.admin
           end
+        end
+      end
+
+      around do |e|
+        Graphiti.with_context(OpenStruct.new(admin: false)) do
+          e.run
         end
       end
 
@@ -733,8 +739,6 @@ RSpec.describe "serialization" do
 
       it "is not applied to the serializer" do
         PORO::Employee.create(first_name: "John")
-        allow_any_instance_of(position_resource).to receive(:admin?).and_return(false)
-        expect(position_resource.new.admin?).to be_falsey
         render
         expect(json.dig("data", 0, "relationships", "positions")).to be_falsey
       end

--- a/spec/sideloading_spec.rb
+++ b/spec/sideloading_spec.rb
@@ -1047,7 +1047,7 @@ RSpec.describe "sideloading" do
 
     describe "across requests" do
       it "uses a different sideloaded resource" do
-        ctx = double(current_user: :admin)
+        ctx = double(current_user: :admin, admin: true)
         sl1 = Graphiti.with_context ctx do
           resource.all(params).query.sideloads.values[0].resource
         end

--- a/spec/stats_spec.rb
+++ b/spec/stats_spec.rb
@@ -125,7 +125,8 @@ RSpec.describe "stats" do
         let(:ctx) do
           double "stat context",
             current_user: double.as_null_object,
-            my_stat: 1338
+            my_stat: 1338,
+            admin: true
         end
 
         before do


### PR DESCRIPTION
Relevant slack discussion here:

https://graphiti-api.slack.com/archives/C5A4UEMGS/p1586786246081700

The example given from  ^ is 

```ruby
class EmployeeResource < Graphiti::Resource
  belongs_to :company, writeable: :user_can_modify_company
  def user_can_modify_company
     CompanyPolicy.new(resource, context.current_user).update?
  end
end
```

I'm assuming from above the intention is to have sideload  configurable per request but currently the `user_can_modify_company` method above instead of being lazily called will be fired once on class load and the return value used thereafter.

I've added a failing spec here which appears to recreate this issue but I'm not sure honestly. 

I did dig around @richmolj for a fix but no joy.  I guess jsonrb still does the rendering so is it the case that graphiti simply passes the include parameter to jsonrb's render method based on resource logic (i.e is this definitely a graphiti issue?)
