### PR TITLE
Allow attribute guard to receive name

### DIFF
--- a/lib/graphiti/util/serializer_attributes.rb
+++ b/lib/graphiti/util/serializer_attributes.rb
@@ -55,13 +55,16 @@ module Graphiti
       def guard
         method_name = @attr[:readable]
         instance = @resource.new
+        attribute = @name.to_s
 
         -> {
           method = instance.method(method_name)
           if method.arity.zero?
             instance.instance_eval(&method_name)
-          else
+          elsif method.arity == 1
             instance.instance_exec(@object, &method)
+          else
+            instance.instance_exec(@object, attribute, &method)
           end
         }
       end

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -775,11 +775,26 @@ RSpec.describe "serialization" do
         end
       end
 
-      context "and the guard accepts an argument" do
+      context "and the guard accepts a single argument" do
         before do
           resource.class_eval do
             def admin?(object)
               object.is_a?(PORO::Employee)
+            end
+          end
+        end
+
+        it "is passed the model instance as argument" do
+          render
+          expect(json["data"][0]["attributes"]["foo"]).to eq("bar")
+        end
+      end
+
+      context "and the guard accepts two arguments" do
+        before do
+          resource.class_eval do
+            def admin?(object, attribute)
+              attribute == "foo"
             end
           end
         end


### PR DESCRIPTION
We have a use case whereby our authorization is quite granular, i.e. we tailor payloads based on a user/role per request.

This PR would allow attribute guard methods to optionally receive the name of the current attribute in addition to the current object.

```ruby
attribute :foo, :string, readable: :bar?

def bar?(object, attribute)
   # Check if current user has a permission allowing them to read foo attribute
   authorize_attribute(context.current_user, attribute) #=> false
end
```

I realize not many applications will require this level of granularity but it seems like a relatively minor change in the scheme of things so I thought I'd ask anyway.