### PR TITLE
Bump `jsonapi-renderer` to `~0.2.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 Features:
-
+- [242](https://github.com/graphiti-api/graphiti/pull/242) Bump `jsonapi-renderer` to `~0.2.2` now that (https://github.com/jsonapi-rb/jsonapi-renderer/pull/36) is fixed.
 - [158](https://github.com/graphiti-api/graphiti/pull/158) Filters options `allow_nil: true`
   Option can be set at the resource level `Resource.filters_accept_nil_by_default = true`. 
   By default this is set to false. (@zeisler)

--- a/graphiti.gemspec
+++ b/graphiti.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.3"
 
   spec.add_dependency "jsonapi-serializable", "~> 0.3.0"
-  spec.add_dependency "jsonapi-renderer", "0.2.0"
+  spec.add_dependency "jsonapi-renderer", "~> 0.2", ">= 0.2.2"
   spec.add_dependency "dry-types", ">= 0.15.0", "< 2.0"
   spec.add_dependency "graphiti_errors", "~> 1.1.0"
   spec.add_dependency "concurrent-ruby", "~> 1.0"


### PR DESCRIPTION
Bump `jsonapi-renderer` to `~0.2.2` now that (https://github.com/jsonapi-rb/jsonapi-renderer/pull/36) is fixed.