### PR TITLE
Add action to query

### DIFF
--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -11,8 +11,7 @@ module Graphiti
       @params = @params.deep_symbolize_keys
       @include_param = nested_include || @params[:include]
       @parents = parents
-      @action = action || @params.fetch(:action, Graphiti.context[:namespace]).try(:to_sym)
-      @action = %i[index show].include?(@action) ? :read : @action
+      @action = parse_action(action)
     end
 
     def association?
@@ -97,7 +96,7 @@ module Graphiti
               sl_resource = resource_for_sideload(sideload)
               query_parents = parents + [self]
               sub_hash = sub_hash[:include] if sub_hash.key?(:include)
-              hash[key] = Query.new(sl_resource, @params, key, sub_hash, query_parents, :read)
+              hash[key] = Query.new(sl_resource, @params, key, sub_hash, query_parents, :all)
             else
               handle_missing_sideload(key)
             end
@@ -317,5 +316,18 @@ module Graphiti
         end
       end
     end
+
+    def parse_action(action)
+      action ||= @params.fetch(:action, Graphiti.context[:namespace]).try(:to_sym)
+      case action
+      when :index
+        :all
+      when :show
+        :find
+      else
+        action
+      end
+    end
+
   end
 end

--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -1,8 +1,8 @@
 module Graphiti
   class Query
-    attr_reader :resource, :association_name, :params
+    attr_reader :resource, :association_name, :params, :action
 
-    def initialize(resource, params, association_name = nil, nested_include = nil, parents = [])
+    def initialize(resource, params, association_name = nil, nested_include = nil, parents = [], action = nil)
       @resource = resource
       @association_name = association_name
       @params = params
@@ -11,6 +11,8 @@ module Graphiti
       @params = @params.deep_symbolize_keys
       @include_param = nested_include || @params[:include]
       @parents = parents
+      @action = action || @params.fetch(:action, Graphiti.context[:namespace]).try(:to_sym)
+      @action = %i[index show].include?(@action) ? :read : @action
     end
 
     def association?
@@ -95,7 +97,7 @@ module Graphiti
               sl_resource = resource_for_sideload(sideload)
               query_parents = parents + [self]
               sub_hash = sub_hash[:include] if sub_hash.key?(:include)
-              hash[key] = Query.new(sl_resource, @params, key, sub_hash, query_parents)
+              hash[key] = Query.new(sl_resource, @params, key, sub_hash, query_parents, :read)
             else
               handle_missing_sideload(key)
             end

--- a/lib/graphiti/resource/interface.rb
+++ b/lib/graphiti/resource/interface.rb
@@ -11,7 +11,7 @@ module Graphiti
 
         # @api private
         def _all(params, opts, base_scope)
-          runner = Runner.new(self, params, opts.delete(:query), :read)
+          runner = Runner.new(self, params, opts.delete(:query), :all)
           opts[:params] = params
           runner.proxy(base_scope, opts)
         end
@@ -27,7 +27,7 @@ module Graphiti
           params[:filter] ||= {}
           params[:filter][:id] = id if id
 
-          runner = Runner.new(self, params, nil, :read)
+          runner = Runner.new(self, params, nil, :find)
           runner.proxy base_scope,
             single: true,
             raise_on_missing: true,

--- a/lib/graphiti/resource/interface.rb
+++ b/lib/graphiti/resource/interface.rb
@@ -11,7 +11,7 @@ module Graphiti
 
         # @api private
         def _all(params, opts, base_scope)
-          runner = Runner.new(self, params, opts.delete(:query))
+          runner = Runner.new(self, params, opts.delete(:query), :read)
           opts[:params] = params
           runner.proxy(base_scope, opts)
         end
@@ -27,7 +27,7 @@ module Graphiti
           params[:filter] ||= {}
           params[:filter][:id] = id if id
 
-          runner = Runner.new(self, params)
+          runner = Runner.new(self, params, nil, :read)
           runner.proxy base_scope,
             single: true,
             raise_on_missing: true,

--- a/lib/graphiti/runner.rb
+++ b/lib/graphiti/runner.rb
@@ -3,10 +3,11 @@ module Graphiti
     attr_reader :params
     attr_reader :deserialized_payload
 
-    def initialize(resource_class, params, query = nil)
+    def initialize(resource_class, params, query = nil, action = nil)
       @resource_class = resource_class
       @params = params
       @query = query
+      @action = action
 
       validator = RequestValidator.new(jsonapi_resource, params)
 
@@ -30,7 +31,7 @@ module Graphiti
     end
 
     def query
-      @query ||= Query.new(jsonapi_resource, params)
+      @query ||= Query.new(jsonapi_resource, params, nil, nil, [], @action)
     end
 
     def query_hash

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -962,12 +962,12 @@ RSpec.describe Graphiti::Query do
 
       context "and the action provided is show" do
         let(:provided_action) { :show }
-        it { is_expected.to eq(:read) }
+        it { is_expected.to eq(:find) }
       end
 
       context "and the action provided is index" do
         let(:provided_action) { :index }
-        it { is_expected.to eq(:read) }
+        it { is_expected.to eq(:all) }
       end
     end
 
@@ -990,7 +990,7 @@ RSpec.describe Graphiti::Query do
       subject(:sideloads) { instance.sideloads }
 
       it "does not cascate the action" do
-        expect(sideloads.values.map(&:action)).to eq([:read])
+        expect(sideloads.values.map(&:action)).to eq([:all])
       end
     end
   end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -1138,6 +1138,11 @@ RSpec.describe Graphiti::Resource do
         expect(employees.map(&:id)).to eq([employee2.id])
       end
 
+      describe "when no arguments are provided" do
+        subject { klass.all.map(&:id) }
+        it { is_expected.to contain_exactly(employee1.id, employee2.id, employee3.id) }
+      end
+
       context "when running within a request context" do
         before do
           klass.class_eval do

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -21,14 +21,32 @@ RSpec.describe Graphiti::Runner do
   end
 
   describe "#proxy" do
+    let(:proxy) { instance.proxy("foo") }
+    let(:scope) { double(resolve: ["resolved"]) }
+    before { allow(instance).to receive(:jsonapi_scope).and_return(scope) }
+
     it "returns a proxy with access to records, stats, and query" do
-      scope = double(resolve: ["resolved"])
       expect(instance).to receive(:jsonapi_scope).with("foo", {}) { scope }
-      proxy = instance.proxy("foo")
       expect(proxy).to be_a(Graphiti::ResourceProxy)
       expect(proxy.query).to be_a(Graphiti::Query)
       expect(proxy.to_a).to eq(["resolved"])
       expect(proxy.stats).to eq({})
+    end
+
+    describe "the proxy's query" do
+      subject(:query) { proxy.query }
+
+      context "when an action is provided" do
+        let(:instance) { described_class.new(resource_class, params, nil, :action) }
+        it { expect(query.action).to eq(:action) }
+      end
+
+      context "when a query is provided" do
+        let(:provided_query) { double(:provided_query) }
+        let(:instance) { described_class.new(resource_class, params, provided_query) }
+
+        it { is_expected.to eq(provided_query) }
+      end
     end
   end
 end


### PR DESCRIPTION
When performing a write activity on a resource and sideloading a
secondary, related resource, e.g. by `POST /resource/:id?include=related`
the namespace points to the original action for both the primary and
included resources.

This is useful because it provides context for the overall request, but
is incomplete and misleading for the action required on the included
resource and becomes problematic with authorization where the caller may
have write permission on the primary but only read access to the
sideload, meaning that the `Graphiti.context[:namespace]` cannot be
used in all cases.

Beacause a query is created for each resource, including those that are
sideloaded or sideposted, this change adds the action to the query
and sets it appropriately to `:read` when the action for that resource
is a read-type and prevents the action being incorrectly cascaded to
included sideloads.