### PR TITLE
Use joins/preload over includes for many_to_many

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -21,7 +21,7 @@ guard :rspec, cmd: "bundle exec rspec --color --format documentation" do
   watch(rails.controllers) do |m|
     [
       rspec.spec.call("controllers/#{m[1]}_controller"),
-      rspec.spec.call("api/#{m[1]}")
+      rspec.spec.call("api/#{m[1]}"),
     ]
   end
 

--- a/lib/graphiti/adapters/active_record/many_to_many_sideload.rb
+++ b/lib/graphiti/adapters/active_record/many_to_many_sideload.rb
@@ -36,7 +36,8 @@ class Graphiti::Adapters::ActiveRecord::ManyToManySideload < Graphiti::Sideload:
 
   def filter_for(scope, value, type = nil)
     scope
-      .includes(through_relationship_name)
+      .preload(through_relationship_name)
+      .joins(through_relationship_name)
       .where(belongs_to_many_clause(value, type))
   end
 

--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -328,6 +328,5 @@ module Graphiti
         action
       end
     end
-
   end
 end

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "filtering" do
     context "and an array of json objects passed" do
       before do
         params[:filter] = {
-          by_json: '{ "id": 2, "id2": 3 },{ "id": 4 },{ "id": 5 },{ "id": 6 }'
+          by_json: '{ "id": 2, "id2": 3 },{ "id": 4 },{ "id": 5 },{ "id": 6 }',
         }
       end
 
@@ -115,8 +115,8 @@ RSpec.describe "filtering" do
           params[:filter] = {
             by_json: {
               users: {update: {id: {a: 2, b: 3}}},
-              admins: {update: {id: {a: 2, b: 3}}}
-            }.to_json
+              admins: {update: {id: {a: 2, b: 3}}},
+            }.to_json,
           }
         end
 
@@ -141,8 +141,8 @@ RSpec.describe "filtering" do
         params[:filter] = {
           by_json: [
             {id: [{a: 2}, {b: 3}]}.to_json,
-            {id: [{a: 2}, {b: 3}]}.to_json
-          ].join(",")
+            {id: [{a: 2}, {b: 3}]}.to_json,
+          ].join(","),
         }
       end
 
@@ -181,7 +181,7 @@ RSpec.describe "filtering" do
         write: foo,
         kind: "record",
         canonical_name: :hash,
-        description: "Foo"
+        description: "Foo",
       }
       resource.filter :blah, :custom do
         eq do |scope, hash|
@@ -221,7 +221,7 @@ RSpec.describe "filtering" do
         expect(records.map(&:id)).to eq([
           employee1.id,
           employee2.id,
-          employee4.id
+          employee4.id,
         ])
       end
     end
@@ -443,7 +443,7 @@ RSpec.describe "filtering" do
       before do
         params[:filter] = {
           id: employee1.id,
-          'positions.title': "bar"
+          'positions.title': "bar",
         }
         params[:include] = "positions"
       end
@@ -470,7 +470,7 @@ RSpec.describe "filtering" do
       before do
         params[:filter] = {
           id: employee1.id,
-          'positions.department.name': "bar"
+          'positions.department.name': "bar",
         }
         params[:include] = "positions.department"
       end
@@ -762,7 +762,7 @@ RSpec.describe "filtering" do
         params[:filter] = {
           foo: "a",
           bar: "b",
-          baz: "c"
+          baz: "c",
         }
       end
 
@@ -1134,10 +1134,10 @@ RSpec.describe "filtering" do
             "foo" => {
               "eq" => {
                 "bar" => {
-                  "baz" => "blah"
-                }
-              }
-            }
+                  "baz" => "blah",
+                },
+              },
+            },
           }
         end
 
@@ -1274,7 +1274,7 @@ RSpec.describe "filtering" do
           read: type,
           write: type,
           kind: "scalar",
-          description: "test"
+          description: "test",
         }
         resource.attribute :foo, :custom
       end
@@ -1319,7 +1319,7 @@ RSpec.describe "filtering" do
           :suffix,
           :not_suffix,
           :match,
-          :not_match
+          :not_match,
         ])
         expect(resource.filters[:foo][:operators][:eq]).to be_a(Proc)
         expect(resource.filters[:foo][:operators][:suffix]).to be_nil
@@ -1429,7 +1429,7 @@ RSpec.describe "filtering" do
 
         it "limits available operators" do
           expect(resource.filters[:foo][:operators].keys).to eq([
-            :gt, :gte, :lt, :lte, :foo
+            :gt, :gte, :lt, :lte, :foo,
           ])
         end
       end
@@ -1444,7 +1444,7 @@ RSpec.describe "filtering" do
 
         it "limits available operators, adding custom ones" do
           expect(resource.filters[:foo][:operators].keys).to eq([
-            :gt, :gte, :lt, :lte, :foo
+            :gt, :gte, :lt, :lte, :foo,
           ])
         end
       end
@@ -1456,7 +1456,7 @@ RSpec.describe "filtering" do
 
         it "limits available operators" do
           expect(resource.filters[:foo][:operators].keys).to eq([
-            :not_eq, :gt, :gte, :lt, :lte
+            :not_eq, :gt, :gte, :lt, :lte,
           ])
         end
       end

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -80,6 +80,11 @@ ActiveRecord::Schema.define(version: 1) do
   create_table :tags do |t|
     t.string :name
   end
+
+  create_table :author_mentorships do |t|
+    t.integer :mentor_id
+    t.integer :mentee_id
+  end
 end
 
 module Legacy
@@ -112,6 +117,19 @@ module Legacy
     belongs_to :special_state,
       -> { where(id: 9999) },
       class_name: "Legacy::State"
+
+    has_many :mentor_joins, class_name: "AuthorMentorship",
+                            foreign_key: :mentee_id, inverse_of: :mentee
+    has_many :mentors, through: :mentor_joins, class_name: "Author", source: :mentor
+
+    has_many :mentee_joins, class_name: "AuthorMentorship",
+                            foreign_key: :mentor_id, inverse_of: :mentor
+    has_many :mentees, through: :mentee_joins, class_name: "Author", source: :mentee
+  end
+
+  class AuthorMentorship < ApplicationRecord
+    belongs_to :mentor, class_name: "Author"
+    belongs_to :mentee, class_name: "Author"
   end
 
   class Organization < ApplicationRecord

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -868,7 +868,7 @@ if ENV["APPRAISAL_INITIALIZED"]
           "birthdays" => 70, # alias
           "float_age" => 70.03,
           "decimal_age" => "70.033",
-          "active" => true
+          "active" => true,
         })
         expect(included.map(&:jsonapi_type).uniq).to match_array(%w[books])
       end
@@ -889,7 +889,7 @@ if ENV["APPRAISAL_INITIALIZED"]
         it "is able to sideload without adding the field" do
           do_index({
             fields: {authors: "first_name"},
-            include: "books"
+            include: "books",
           })
           expect(json["data"][0]["relationships"]).to be_present
           expect(included.map(&:jsonapi_type).uniq).to match_array(%w[books])
@@ -907,7 +907,7 @@ if ENV["APPRAISAL_INITIALIZED"]
         let(:request) do
           do_index({
             include: "books",
-            page: {books: {size: 1, number: 2}}
+            page: {books: {size: 1, number: 2}},
           })
         end
 
@@ -1076,7 +1076,7 @@ if ENV["APPRAISAL_INITIALIZED"]
       it "allows filtering of sideloaded resource" do
         do_index({
           include: "hobbies",
-          filter: {hobbies: {id: hobby2.id}}
+          filter: {hobbies: {id: hobby2.id}},
         })
         expect(included("hobbies").map(&:id)).to eq([hobby2.id])
       end
@@ -1084,7 +1084,7 @@ if ENV["APPRAISAL_INITIALIZED"]
       it "allows extra fields for sideloaded resource" do
         do_index({
           include: "hobbies",
-          extra_fields: {hobbies: "reason"}
+          extra_fields: {hobbies: "reason"},
         })
         hobby = included("hobbies")[0]
         expect(hobby["name"]).to be_present
@@ -1104,7 +1104,7 @@ if ENV["APPRAISAL_INITIALIZED"]
         do_index({
           include: "hobbies",
           fields: {hobbies: "name"},
-          extra_fields: {hobbies: "reason"}
+          extra_fields: {hobbies: "reason"},
         })
         hobby = included("hobbies")[0]
         expect(hobby).to have_key("name")
@@ -1116,7 +1116,7 @@ if ENV["APPRAISAL_INITIALIZED"]
         do_index({
           include: "hobbies,books",
           fields: {hobbies: "name", books: "title"},
-          extra_fields: {hobbies: "reason", books: "alternate_title"}
+          extra_fields: {hobbies: "reason", books: "alternate_title"},
         })
         hobby = included("hobbies")[0]
         book = included("books")[0]
@@ -1173,37 +1173,37 @@ if ENV["APPRAISAL_INITIALIZED"]
         before do
           Legacy::AuthorResource.class_eval do
             many_to_many :mentors,
-              foreign_key: { :mentee_joins => :mentee_id },
+              foreign_key: {mentee_joins: :mentee_id},
               resource: Legacy::AuthorResource
 
             many_to_many :mentees,
-              foreign_key: { :mentor_joins => :mentor_id },
+              foreign_key: {mentor_joins: :mentor_id},
               resource: Legacy::AuthorResource
           end
         end
 
-        let!(:author_with_mentors) { Legacy::Author.create!(first_name: 'Fred') }
-        let!(:author_with_mentees) { Legacy::Author.create!(first_name: 'George') }
-        let!(:author_with_both) { Legacy::Author.create!(first_name: 'Alice') }
+        let!(:author_with_mentors) { Legacy::Author.create!(first_name: "Fred") }
+        let!(:author_with_mentees) { Legacy::Author.create!(first_name: "George") }
+        let!(:author_with_both) { Legacy::Author.create!(first_name: "Alice") }
 
         before do
           author_with_mentors.mentors = [author_with_mentees, author_with_both]
           author_with_mentees.mentees = [author_with_mentors, author_with_both]
         end
 
-        it 'still works' do
+        it "still works" do
           do_index({include: "mentors"})
           target = d.find { |e| e.id == author_with_mentors.id }
-          expect(target.relationships['mentors']).to eq({
+          expect(target.relationships["mentors"]).to eq({
             "data" => [
               {"type" => "authors", "id" => author_with_mentees.id.to_s},
-              {"type" => "authors", "id" => author_with_both.id.to_s}
-            ]
+              {"type" => "authors", "id" => author_with_both.id.to_s},
+            ],
           })
         end
 
-        it 'allows filtering by the association' do
-          do_index({filter: { mentor_id: author_with_mentees.id }})
+        it "allows filtering by the association" do
+          do_index({filter: {mentor_id: author_with_mentees.id}})
 
           expect(d.map(&:id)).to eq([author_with_mentors.id, author_with_both.id])
         end
@@ -1289,9 +1289,9 @@ if ENV["APPRAISAL_INITIALIZED"]
                 filter: {
                   taggable_id: [
                     {id: author1.id, type: author1.class.name}.to_json,
-                    {id: book2.id, type: book2.class.name}.to_json
-                  ]
-                }
+                    {id: book2.id, type: book2.class.name}.to_json,
+                  ],
+                },
               })
               expect(d.map(&:name)).to eq(%w[One Two Three])
             end
@@ -1327,7 +1327,7 @@ if ENV["APPRAISAL_INITIALIZED"]
         book2.save!
         do_index({
           filter: {books: {id: book1.id}, other_books: {id: book2.id}},
-          include: "books.genre,other_books.genre"
+          include: "books.genre,other_books.genre",
         })
         expect(included("genres").length).to eq(2)
       end
@@ -1337,7 +1337,7 @@ if ENV["APPRAISAL_INITIALIZED"]
       it "allows extra fields for the sideloaded resource" do
         do_index({
           include: "dwelling",
-          extra_fields: {houses: "house_price", condos: "condo_price"}
+          extra_fields: {houses: "house_price", condos: "condo_price"},
         })
         house = included("houses")[0]
         expect(house["name"]).to be_present
@@ -1352,7 +1352,7 @@ if ENV["APPRAISAL_INITIALIZED"]
       it "allows sparse fieldsets for the sideloaded resource" do
         do_index({
           include: "dwelling",
-          fields: {houses: "name", condos: "condo_description"}
+          fields: {houses: "name", condos: "condo_description"},
         })
         house = included("houses")[0]
         expect(house["name"]).to be_present
@@ -1368,7 +1368,7 @@ if ENV["APPRAISAL_INITIALIZED"]
         do_index({
           include: "dwelling",
           fields: {houses: "name", condos: "condo_description"},
-          extra_fields: {houses: "house_price", condos: "condo_price"}
+          extra_fields: {houses: "house_price", condos: "condo_price"},
         })
         house = included("houses")[0]
         condo = included("condos")[0]

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Graphiti::Query do
     describe "includes" do
       let(:expected) do
         {
-          positions: {include: {department: {}}}
+          positions: {include: {department: {}}},
         }
       end
 
@@ -81,10 +81,10 @@ RSpec.describe Graphiti::Query do
             include: {
               positions: {
                 include: {
-                  department: {}
-                }
-              }
-            }
+                  department: {},
+                },
+              },
+            },
           })
         end
       end
@@ -200,7 +200,7 @@ RSpec.describe Graphiti::Query do
           params[:filter] = {
             name: "foo",
             positions: {title: "bar"},
-            departments: {description: "baz"}
+            departments: {description: "baz"},
           }
         end
 
@@ -212,11 +212,11 @@ RSpec.describe Graphiti::Query do
                 filter: {title: "bar"},
                 include: {
                   department: {
-                    filter: {description: "baz"}
-                  }
-                }
-              }
-            }
+                    filter: {description: "baz"},
+                  },
+                },
+              },
+            },
           }
         end
 
@@ -241,7 +241,7 @@ RSpec.describe Graphiti::Query do
           params[:filter] = {
             name: "foo",
             positions: {title: "bar"},
-            department: {description: "baz"}
+            department: {description: "baz"},
           }
         end
 
@@ -253,11 +253,11 @@ RSpec.describe Graphiti::Query do
                 filter: {title: "bar"},
                 include: {
                   department: {
-                    filter: {description: "baz"}
-                  }
-                }
-              }
-            }
+                    filter: {description: "baz"},
+                  },
+                },
+              },
+            },
           }
         end
 
@@ -298,10 +298,10 @@ RSpec.describe Graphiti::Query do
               positions: {
                 filter: {title: {eq: "asdf"}},
                 include: {
-                  department: {}
-                }
-              }
-            }
+                  department: {},
+                },
+              },
+            },
           }
         end
 
@@ -320,11 +320,11 @@ RSpec.describe Graphiti::Query do
                 positions: {
                   include: {
                     department: {
-                      filter: {name: {eq: "asdf"}}
-                    }
-                  }
-                }
-              }
+                      filter: {name: {eq: "asdf"}},
+                    },
+                  },
+                },
+              },
             }
           end
 
@@ -438,11 +438,11 @@ RSpec.describe Graphiti::Query do
                 sort: [{title: :asc}, {rank: :desc}],
                 include: {
                   department: {
-                    sort: [{description: :desc}]
-                  }
-                }
-              }
-            }
+                    sort: [{description: :desc}],
+                  },
+                },
+              },
+            },
           }
         end
 
@@ -474,11 +474,11 @@ RSpec.describe Graphiti::Query do
                 sort: [{title: :asc}, {rank: :desc}],
                 include: {
                   department: {
-                    sort: [{description: :desc}]
-                  }
-                }
-              }
-            }
+                    sort: [{description: :desc}],
+                  },
+                },
+              },
+            },
           }
         end
 
@@ -508,11 +508,11 @@ RSpec.describe Graphiti::Query do
               positions: {
                 include: {
                   department: {
-                    sort: [{name: :desc}]
-                  }
-                }
-              }
-            }
+                    sort: [{name: :desc}],
+                  },
+                },
+              },
+            },
           }
         end
 
@@ -528,7 +528,7 @@ RSpec.describe Graphiti::Query do
           params[:page] = {
             number: 2, size: 1,
             positions: {number: 3, size: 2},
-            departments: {number: 4, size: 3}
+            departments: {number: 4, size: 3},
           }
         end
 
@@ -540,11 +540,11 @@ RSpec.describe Graphiti::Query do
                 page: {number: 3, size: 2},
                 include: {
                   department: {
-                    page: {number: 4, size: 3}
-                  }
-                }
-              }
-            }
+                    page: {number: 4, size: 3},
+                  },
+                },
+              },
+            },
           }
         end
 
@@ -568,7 +568,7 @@ RSpec.describe Graphiti::Query do
           params[:page] = {
             number: 2, size: 1,
             positions: {number: 3, size: 2},
-            department: {number: 4, size: 3}
+            department: {number: 4, size: 3},
           }
         end
 
@@ -580,11 +580,11 @@ RSpec.describe Graphiti::Query do
                 page: {number: 3, size: 2},
                 include: {
                   department: {
-                    page: {number: 4, size: 3}
-                  }
-                }
-              }
-            }
+                    page: {number: 4, size: 3},
+                  },
+                },
+              },
+            },
           }
         end
 
@@ -610,7 +610,7 @@ RSpec.describe Graphiti::Query do
             'positions.size': 2,
             'positions.number': 3,
             'positions.department.size': 3,
-            'positions.department.number': 4
+            'positions.department.number': 4,
           }
         end
 
@@ -622,11 +622,11 @@ RSpec.describe Graphiti::Query do
                 page: {number: 3, size: 2},
                 include: {
                   department: {
-                    page: {number: 4, size: 3}
-                  }
-                }
-              }
-            }
+                    page: {number: 4, size: 3},
+                  },
+                },
+              },
+            },
           }
         end
 
@@ -667,7 +667,7 @@ RSpec.describe Graphiti::Query do
           params[:fields] = {
             employees: "first_name,last_name",
             positions: "title",
-            departments: "description"
+            departments: "description",
           }
         end
 
@@ -676,15 +676,15 @@ RSpec.describe Graphiti::Query do
             fields: {
               employees: [:first_name, :last_name],
               positions: [:title],
-              departments: [:description]
+              departments: [:description],
             },
             include: {
               positions: {
                 include: {
-                  department: {}
-                }
-              }
-            }
+                  department: {},
+                },
+              },
+            },
           }
         end
 
@@ -731,7 +731,7 @@ RSpec.describe Graphiti::Query do
           params[:extra_fields] = {
             employees: "foo,bar",
             positions: "baz",
-            departments: "bax"
+            departments: "bax",
           }
         end
 
@@ -740,18 +740,18 @@ RSpec.describe Graphiti::Query do
             extra_fields: {
               employees: [:foo, :bar],
               positions: [:baz],
-              departments: [:bax]
+              departments: [:bax],
             },
             include: {
               positions: {
                 extra_fields: {positions: [:baz]},
                 include: {
                   department: {
-                    extra_fields: {departments: [:bax]}
-                  }
-                }
-              }
-            }
+                    extra_fields: {departments: [:bax]},
+                  },
+                },
+              },
+            },
           }
         end
 
@@ -774,28 +774,28 @@ RSpec.describe Graphiti::Query do
     context "when fields are also present" do
       before do
         params[:fields] = {
-          employees: "foo,bar"
+          employees: "foo,bar",
         }
         params[:extra_fields] = {
-          employees: "baz,bax"
+          employees: "baz,bax",
         }
       end
 
       it "adds extra fields to fields" do
         expect(hash).to eq({
           fields: {
-            employees: [:foo, :bar, :baz, :bax]
+            employees: [:foo, :bar, :baz, :bax],
           },
           extra_fields: {
-            employees: [:baz, :bax]
+            employees: [:baz, :bax],
           },
           include: {
             positions: {
               include: {
-                department: {}
-              }
-            }
-          }
+                department: {},
+              },
+            },
+          },
         })
       end
     end
@@ -811,10 +811,10 @@ RSpec.describe Graphiti::Query do
           include: {
             positions: {
               include: {
-                department: {}
-              }
-            }
-          }
+                department: {},
+              },
+            },
+          },
         }
       end
 
@@ -985,7 +985,7 @@ RSpec.describe Graphiti::Query do
       it { is_expected.to eq(provided_action) }
     end
 
-    describe 'sideloads' do
+    describe "sideloads" do
       before { params[:include] = "positions" }
       subject(:sideloads) { instance.sideloads }
 

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "serialization" do
           read: type,
           write: type,
           kind: "scalar",
-          description: "test"
+          description: "test",
         }
         resource.attribute :id, :custom
       end
@@ -565,7 +565,7 @@ RSpec.describe "serialization" do
             write: type,
             params: type,
             kind: "scalar",
-            description: "test"
+            description: "test",
           }
           resource.attribute :age, :custom
         end
@@ -674,7 +674,7 @@ RSpec.describe "serialization" do
         attributes = data["attributes"]
         expect(attributes).to eq({
           "foo" => "without object",
-          "bar" => "JOHN"
+          "bar" => "JOHN",
         })
       end
     end
@@ -834,7 +834,7 @@ RSpec.describe "serialization" do
       render
       expect(json["data"][0]["attributes"]).to eq({
         "foo" => "bar",
-        "first_name" => "John"
+        "first_name" => "John",
       })
     end
 


### PR DESCRIPTION
Ran into a strange edge case with activerecord's include behavior when
doing many_to_many relationship on a self-referential model. Still can't
quite figure out what the includes issue is, but I think it is actually
a bug in activerecord.  This commit switches to use a combination of
joins/preload when loading the assocation, which seems to do the trick.