### PR TITLE
Allow custom names for many_to_many filters

### DIFF
--- a/lib/graphiti/sideload/many_to_many.rb
+++ b/lib/graphiti/sideload/many_to_many.rb
@@ -1,4 +1,10 @@
 class Graphiti::Sideload::ManyToMany < Graphiti::Sideload::HasMany
+  def initialize(name, opts)
+    @filter_name_opt = opts[:filter_name]
+
+    super(name, opts)
+  end
+
   def type
     :many_to_many
   end
@@ -11,8 +17,12 @@ class Graphiti::Sideload::ManyToMany < Graphiti::Sideload::HasMany
     foreign_key.values.first
   end
 
+  def filter_name
+    @filter_name_opt || true_foreign_key
+  end
+
   def base_filter(parents)
-    {true_foreign_key => ids_for_parents(parents).join(",")}
+    {filter_name => ids_for_parents(parents).join(",")}
   end
 
   def infer_foreign_key
@@ -32,7 +42,7 @@ class Graphiti::Sideload::ManyToMany < Graphiti::Sideload::HasMany
     self_ref = self
     fk_type = parent_resource_class.attributes[:id][:type]
     fk_type = :hash if polymorphic?
-    resource_class.filter true_foreign_key, fk_type do
+    resource_class.filter filter_name, fk_type do
       eq do |scope, value|
         self_ref.belongs_to_many_filter(scope, value)
       end

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -1194,6 +1194,44 @@ if ENV["APPRAISAL_INITIALIZED"]
         end
       end
 
+      context "when a custom filter_name is provided" do
+        before do
+          Legacy::AuthorResource.class_eval do
+            many_to_many :hobbies, filter_name: :the_id_of_the_author
+          end
+        end
+
+        after do
+          Legacy::AuthorResource.class_eval do
+            many_to_many :hobbies
+          end
+        end
+
+        it "still works" do
+          do_index({include: "hobbies"})
+          expect(included("hobbies").map(&:id)).to eq([hobby1.id, hobby2.id])
+        end
+
+        describe 'filtering relationship' do
+          controller(ApplicationController) do
+            def index
+              records = Legacy::HobbyResource.all(params)
+              render jsonapi: records
+            end
+          end
+
+          before do
+            allow(controller.request.env).to receive(:[])
+              .with("PATH_INFO") { '/legacy/hobbies' }
+          end
+
+          it "can filter the relationship by the custom name" do
+            do_index(filter: { the_id_of_the_author: [author1.id, author2.id].join(',') })
+            expect(d.map(&:id)).to eq([hobby1.id, hobby2.id])
+          end
+        end
+      end
+
       context "when polymorphic many-to-many" do
         let(:tag1) { Legacy::Tag.create!(name: "One") }
         let(:tag2) { Legacy::Tag.create!(name: "Two") }

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -1241,6 +1241,22 @@ RSpec.describe "serialization" do
           expect(json["data"][0]["relationships"]["teams"]["links"]["related"])
             .to eq("/poro/teams?filter[employee_id]=1")
         end
+
+        context 'when the filter_name has been overridden' do
+          def define_relationship
+            resource.many_to_many :teams,
+              filter_name: :the_employee_id,
+              resource: team_resource,
+              foreign_key: {employee_teams: :employee_id}
+          end
+
+          it "uses the overridden name" do
+            define_relationship
+            render
+            expect(json["data"][0]["relationships"]["teams"]["links"]["related"])
+              .to eq("/poro/teams?filter[the_employee_id]=1")
+          end
+        end
       end
 
       context "and a has_one relationship" do


### PR DESCRIPTION
When creating a many_to_many relationship, graphiti adds a filter to the
foreign resource which is used when sideloading or provided as a link to
the relationship scope if link generation is enabled.  Sometimes,
however, the id of the field being looked up is an internal value and
might not be something you'd want to expose to the API itself.  This
allows us to pass a `filter_name` option when setting up many_to_many,
which it will use for the lookups.