### PR TITLE
Change filter_name => inverse_filter

### DIFF
--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -132,6 +132,10 @@ module Graphiti
       end
     end
 
+    def link_filter(parents)
+      base_filter(parents)
+    end
+
     # The parent resource is a remote,
     # AND the sideload is a remote to the same endpoint
     def shared_remote?

--- a/lib/graphiti/sideload/has_many.rb
+++ b/lib/graphiti/sideload/has_many.rb
@@ -1,6 +1,16 @@
 class Graphiti::Sideload::HasMany < Graphiti::Sideload
+  def initialize(name, opts)
+    @inverse_filter = opts[:inverse_filter]
+
+    super(name, opts)
+  end
+
   def type
     :has_many
+  end
+
+  def inverse_filter
+    @inverse_filter || foreign_key
   end
 
   def load_params(parents, query)
@@ -11,10 +21,18 @@ class Graphiti::Sideload::HasMany < Graphiti::Sideload
   end
 
   def base_filter(parents)
-    {foreign_key => ids_for_parents(parents).join(",")}
+    {foreign_key => parent_filter(parents)}
+  end
+
+  def link_filter(parents)
+    {inverse_filter => parent_filter(parents)}
   end
 
   private
+
+  def parent_filter(parents)
+    ids_for_parents(parents).join(",")
+  end
 
   def child_map(children)
     children.group_by(&foreign_key)

--- a/lib/graphiti/sideload/many_to_many.rb
+++ b/lib/graphiti/sideload/many_to_many.rb
@@ -1,10 +1,4 @@
 class Graphiti::Sideload::ManyToMany < Graphiti::Sideload::HasMany
-  def initialize(name, opts)
-    @filter_name_opt = opts[:filter_name]
-
-    super(name, opts)
-  end
-
   def type
     :many_to_many
   end
@@ -17,12 +11,12 @@ class Graphiti::Sideload::ManyToMany < Graphiti::Sideload::HasMany
     foreign_key.values.first
   end
 
-  def filter_name
-    @filter_name_opt || true_foreign_key
+  def inverse_filter
+    @inverse_filter || true_foreign_key
   end
 
   def base_filter(parents)
-    {filter_name => ids_for_parents(parents).join(",")}
+    {true_foreign_key => parent_filter(parents)}
   end
 
   def infer_foreign_key
@@ -42,7 +36,7 @@ class Graphiti::Sideload::ManyToMany < Graphiti::Sideload::HasMany
     self_ref = self
     fk_type = parent_resource_class.attributes[:id][:type]
     fk_type = :hash if polymorphic?
-    resource_class.filter filter_name, fk_type do
+    resource_class.filter inverse_filter, fk_type do
       eq do |scope, value|
         self_ref.belongs_to_many_filter(scope, value)
       end

--- a/lib/graphiti/util/link.rb
+++ b/lib/graphiti/util/link.rb
@@ -60,7 +60,7 @@ module Graphiti
       def params
         @params ||= {}.tap do |params|
           if @sideload.type != :belongs_to || @sideload.remote?
-            params[:filter] = @sideload.base_filter([@model])
+            params[:filter] = @sideload.link_filter([@model])
           end
 
           @sideload.params_proc&.call(params, [@model], context)

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -968,6 +968,25 @@ if ENV["APPRAISAL_INITIALIZED"]
         expect(book).to have_key("alternate_title")
         expect(book).to_not have_key("title")
       end
+
+      context "when a custom inverse_filter is provided" do
+        before do
+          Legacy::AuthorResource.class_eval do
+            has_many :books, inverse_filter: :some_author_id
+          end
+        end
+
+        after do
+          Legacy::AuthorResource.class_eval do
+            has_many :books
+          end
+        end
+
+        it "still works" do
+          do_index({include: "books"})
+          expect(included("books").map(&:id)).to eq([book1.id, book2.id])
+        end
+      end
     end
 
     context "sideloading belongs_to" do
@@ -1234,10 +1253,10 @@ if ENV["APPRAISAL_INITIALIZED"]
         end
       end
 
-      context "when a custom filter_name is provided" do
+      context "when a custom inverse_filter is provided" do
         before do
           Legacy::AuthorResource.class_eval do
-            many_to_many :hobbies, filter_name: :the_id_of_the_author
+            many_to_many :hobbies, inverse_filter: :the_id_of_the_author
           end
         end
 

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -1043,6 +1043,18 @@ RSpec.describe "serialization" do
           end
         end
 
+        context "and custom filter name is provided" do
+          before do
+            resource.has_many :positions, inverse_filter: :person_id
+          end
+
+          it "links correctly" do
+            render
+            expect(positions["links"]["related"])
+              .to eq("/poro/positions?filter[person_id]=1")
+          end
+        end
+
         context "opting-out of linking" do
           before do
             resource.has_many :positions, link: false
@@ -1242,10 +1254,10 @@ RSpec.describe "serialization" do
             .to eq("/poro/teams?filter[employee_id]=1")
         end
 
-        context 'when the filter_name has been overridden' do
+        context 'when the inverse_filter has been overridden' do
           def define_relationship
             resource.many_to_many :teams,
-              filter_name: :the_employee_id,
+              inverse_filter: :the_employee_id,
               resource: team_resource,
               foreign_key: {employee_teams: :employee_id}
           end


### PR DESCRIPTION
Recent feedback from a user trying to implement the new filter_name
functionality was that they were putting the filter_name override on the
resource at the wrong side of the relationship. Adding inverse to the
argument name matches ActiveRecord's `inverse` argument to a
relationship definition and makes things more clear.

Additionally, I realized that overriding the filter from a link
generation perspective is desireable on has_many sideloads as well, so I
pulled this logic up a level into that sideload class.