### PR TITLE
Fix: filter_datetime_eq method in ActiveRecord adapter doesn't supprt nil

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -159,7 +159,7 @@ module Graphiti
 
       # Ensure fractional seconds don't matter
       def filter_datetime_eq(scope, attribute, value, is_not: false)
-        ranges = value.map { |v| (v..v + 1.second - 0.00000001) }
+        ranges = value.map { |v| (v..v + 1.second - 0.00000001) unless v.nil? }
         clause = {attribute => ranges}
         is_not ? scope.where.not(clause) : scope.where(clause)
       end

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -11,6 +11,7 @@ ActiveRecord::Schema.define(version: 1) do
     t.integer :dwelling_id
     t.integer :organization_id
     t.date :created_at_date
+    t.datetime :last_login
     t.string :identifier
     t.timestamps
   end
@@ -307,9 +308,12 @@ module Legacy
     attribute :float_age, :float
     attribute :decimal_age, :big_decimal
     attribute :active, :boolean
+    attribute :last_login, :datetime, only: [:filterable]
     attribute :created_at, :datetime, only: [:filterable]
     attribute :created_at_date, :date, only: [:filterable]
     attribute :identifier, :uuid
+
+    filter :last_login, allow_nil: true
 
     has_many :books
     belongs_to :state

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -32,6 +32,7 @@ if ENV["APPRAISAL_INITIALIZED"]
                              organization: org1,
                              dwelling: house,
                              created_at: one_day_ago,
+                             last_login: one_day_ago,
                              created_at_date: one_day_ago.to_date,
                              identifier: SecureRandom.uuid
     end
@@ -43,6 +44,7 @@ if ENV["APPRAISAL_INITIALIZED"]
                              decimal_age: 70.011,
                              dwelling: condo,
                              created_at: two_days_ago,
+                             last_login: one_day_ago,
                              created_at_date: two_days_ago.to_date,
                              identifier: SecureRandom.uuid
     end
@@ -106,6 +108,7 @@ if ENV["APPRAISAL_INITIALIZED"]
                                active: true,
                                float_age: 70.05,
                                decimal_age: 70.055,
+                               last_login: nil,
                                created_at: 1.day.from_now,
                                created_at_date: 1.day.from_now.to_date
       end
@@ -585,6 +588,15 @@ if ENV["APPRAISAL_INITIALIZED"]
           it "works" do
             expect(ids).to eq([author2.id])
           end
+
+          context "when value is nil" do
+            let(:filter) { {last_login: value} }
+            let(:value) { {eq: "null"} }
+
+            it "works" do
+              expect(ids).to eq([author3.id])
+            end
+          end
         end
 
         context "!eq" do
@@ -592,6 +604,15 @@ if ENV["APPRAISAL_INITIALIZED"]
 
           it "works" do
             expect(ids).to eq([author1.id, author3.id])
+          end
+
+          context "when value is nil" do
+            let(:filter) { {last_login: value} }
+            let(:value) { {'!eq': "null"} }
+
+            it "works" do
+              expect(ids).to eq([author1.id, author2.id])
+            end
           end
         end
 


### PR DESCRIPTION
This PR fixes an error seen in the ActiveRecord adapter when attempting to filter using nil.

Scenario: In a Rails app, with a resource similar to this the below. filtering by `{ reviewedAt: { eq: "null" } }` from Spraypaint causes error: `NoMethodError (undefined method '+' for nil:NilClass)`
```ruby
class UserRequestResource < ApplicationResource

  primary_endpoint "/admin/user_requests"

  attribute :action, :string
  attribute :first_name, :string
  attribute :last_name, :string
  attribute :reviewed_at, :datetime
  attribute :approved, :boolean

  belongs_to :requester, :resource => UserResource
  belongs_to :reviewer, :resource => UserResource

  filter :reviewed_at, :allow_nil => true

end
```

My workaround for now has been to define a custom filter, but it's not ideal and a permanent fix would be better.
```ruby
filter :reviewed_at, :allow_nil => true  do
    eq do |scope, value|
      scope.where(:reviewed_at => value)
    end
    not_eq do |scope, value|
      scope.where.not(:reviewed_at => value)
    end
  end
```