### PR TITLE
Infer inverse_filter from `inverse_of`

### DIFF
--- a/lib/graphiti/adapters/active_record/many_to_many_sideload.rb
+++ b/lib/graphiti/adapters/active_record/many_to_many_sideload.rb
@@ -8,6 +8,18 @@ class Graphiti::Adapters::ActiveRecord::ManyToManySideload < Graphiti::Sideload:
     foreign_key.keys.first
   end
 
+  def inverse_filter
+    return @inverse_filter if @inverse_filter
+
+    inferred_name = infer_inverse_association
+
+    if inferred_name
+      "#{inferred_name.to_s.singularize}_id"
+    else
+      super
+    end
+  end
+
   def belongs_to_many_filter(scope, value)
     if polymorphic?
       clauses = value.group_by { |v| v["type"] }.map { |group|
@@ -75,5 +87,12 @@ class Graphiti::Adapters::ActiveRecord::ManyToManySideload < Graphiti::Sideload:
     key = parent_reflection.options[:through]
     value = through_reflection.foreign_key.to_sym
     {key => value}
+  end
+
+  def infer_inverse_association
+    through_class = through_reflection.klass
+
+    foreign_reflection = through_class.reflections[name.to_s.singularize]
+    foreign_reflection && foreign_reflection.options[:inverse_of]
   end
 end

--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -5,6 +5,7 @@ module Graphiti
 
       class_methods do
         def filter(name, *args, &blk)
+          name = name.to_sym
           opts = args.extract_options!
           type_override = args[0]
 

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -66,6 +66,15 @@ ActiveRecord::Schema.define(version: 1) do
     t.timestamps
   end
 
+  create_table :readerships do |t|
+    t.integer :user_id
+    t.integer :book_id
+  end
+
+  create_table :users do |t|
+    t.timestamps
+  end
+
   create_table :states do |t|
     t.string :name
     t.timestamps
@@ -174,6 +183,18 @@ module Legacy
     belongs_to :genre
     has_many :taggings, as: :taggable
     has_many :tags, through: :taggings
+    has_many :readerships
+    has_many :readers, through: :readerships, source: :user
+  end
+
+  class User < ApplicationRecord
+    has_many :readerships
+    has_many :books, through: :readerships
+  end
+
+  class Readership < ApplicationRecord
+    belongs_to :user
+    belongs_to :book, inverse_of: :readers
   end
 
   class Tag < ApplicationRecord
@@ -202,6 +223,9 @@ module Legacy
     attribute :name, :string
   end
 
+  class UserResource < ApplicationResource
+  end
+
   class BookResource < ApplicationResource
     attribute :author_id, :integer, only: :filterable
 
@@ -216,6 +240,7 @@ module Legacy
 
     belongs_to :genre
     many_to_many :tags
+    many_to_many :readers, resource: Legacy::UserResource
   end
 
   class StateResource < ApplicationResource

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -1228,6 +1228,42 @@ if ENV["APPRAISAL_INITIALIZED"]
         end
       end
 
+      context "when association name differs from source name" do
+        before do
+          Legacy::UserResource.class_eval do
+            many_to_many :books, resource: Legacy::BookResource
+          end
+          allow(Legacy::BookResource).to receive(:validate_endpoints?) { false }
+          allow(controller).to receive(:resource) { Legacy::BookResource }
+        end
+
+        after do
+          Legacy::UserResource.sideloads.delete(:books)
+        end
+
+        let!(:reader) { Legacy::User.create!(books: [book2]) }
+
+        it "correctly infers the filter name for the association from the inverse_of option" do
+          do_index({filter: {reader_id: reader.id}})
+
+          expect(d.map(&:id)).to eq([book2.id])
+        end
+
+        context "when the graphiti association manually sets inverse_filter" do
+          before do
+            Legacy::UserResource.class_eval do
+              many_to_many :books, resource: Legacy::BookResource, inverse_filter: :the_reader_id
+            end
+          end
+
+          it "overrides the inferred one" do
+            do_index({filter: {the_reader_id: reader.id}})
+
+            expect(d.map(&:id)).to eq([book2.id])
+          end
+        end
+      end
+
       context "when the table name does not match the association name" do
         before do
           Legacy::AuthorHobby.table_name = :author_hobby


### PR DESCRIPTION
If an active_record has_many association provides the `inverse_of`
option, we can infer better filter name for the opposite side of a
many_to_many relationship

Fixes #251, though with a slight change needed on the ActiveRecord definition. 