### PR TITLE
Patch memory leak in Graphiti::Debugger.

### DIFF
--- a/lib/graphiti/debugger.rb
+++ b/lib/graphiti/debugger.rb
@@ -10,6 +10,8 @@ module Graphiti
 
     class << self
       def on_data(name, start, stop, id, payload)
+        return [] unless enabled
+
         took = ((stop - start) * 1000.0).round(2)
         params = scrub_params(payload[:params])
 
@@ -24,7 +26,7 @@ module Graphiti
         end
       end
 
-      def on_data_exception(payload, params)
+      private def on_data_exception(payload, params)
         unless payload[:exception_object].instance_variable_get(:@__graphiti_debug)
           add_chunk do |logs, json|
             logs << ["\n=== Graphiti Debug ERROR", :red, true]
@@ -49,11 +51,11 @@ module Graphiti
         end
       end
 
-      def results(raw_results)
+      private def results(raw_results)
         raw_results.map { |r| "[#{r.class.name}, #{r.id.inspect}]" }.join(", ")
       end
 
-      def on_sideload_data(payload, params, took)
+      private def on_sideload_data(payload, params, took)
         sideload = payload[:sideload]
         results = results(payload[:results])
         add_chunk(payload[:resource], payload[:parent]) do |logs, json|
@@ -72,7 +74,7 @@ module Graphiti
         end
       end
 
-      def on_primary_data(payload, params, took)
+      private def on_primary_data(payload, params, took)
         results = results(payload[:results])
         add_chunk(payload[:resource], payload[:parent]) do |logs, json|
           logs << [""]
@@ -90,6 +92,8 @@ module Graphiti
       end
 
       def on_render(name, start, stop, id, payload)
+        return [] unless enabled
+
         add_chunk do |logs|
           took = ((stop - start) * 1000.0).round(2)
           logs << [""]

--- a/spec/debugger_spec.rb
+++ b/spec/debugger_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Graphiti::Debugger do
-  context 'when disabled' do
+  context "when disabled" do
     around do |example|
       old_value = described_class.enabled
       described_class.enabled = false
@@ -9,13 +9,13 @@ RSpec.describe Graphiti::Debugger do
       described_class.enabled = old_value
     end
 
-    describe '#on_render' do
-      it 'does not add data to chunks Array' do
-        expect { described_class.on_render('foo', 0, 100, :foo, {}) }.not_to change(described_class.chunks, :count)
+    describe "#on_render" do
+      it "does not add data to chunks Array" do
+        expect { described_class.on_render("foo", 0, 100, :foo, {}) }.not_to change(described_class.chunks, :count)
       end
     end
 
-    describe '#on_data' do
+    describe "#on_data" do
       let(:payload) do
         {
           resource: :foo,
@@ -25,8 +25,8 @@ RSpec.describe Graphiti::Debugger do
         }
       end
 
-      it 'does not add data to chunks Array' do
-        expect { described_class.on_data('test', 0, 100, :foo, payload) }.not_to change(described_class.chunks, :count)
+      it "does not add data to chunks Array" do
+        expect { described_class.on_data("test", 0, 100, :foo, payload) }.not_to change(described_class.chunks, :count)
       end
     end
   end

--- a/spec/debugger_spec.rb
+++ b/spec/debugger_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe Graphiti::Debugger do
+  context 'when disabled' do
+    around do |example|
+      old_value = described_class.enabled
+      described_class.enabled = false
+      example.run
+      described_class.enabled = old_value
+    end
+
+    describe '#on_render' do
+      it 'does not add data to chunks Array' do
+        expect { described_class.on_render('foo', 0, 100, :foo, {}) }.not_to change(described_class.chunks, :count)
+      end
+    end
+
+    describe '#on_data' do
+      let(:payload) do
+        {
+          resource: :foo,
+          parent: nil,
+          params: {},
+          results: []
+        }
+      end
+
+      it 'does not add data to chunks Array' do
+        expect { described_class.on_data('test', 0, 100, :foo, payload) }.not_to change(described_class.chunks, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why?
This an attempt to fix #258 in the most focused way possible.

The `Debugger` was adding data to the chunks Array via the `ActiveSupport::Notification` handlers, `on_data`, and `on_render`. When the debugger is disabled, this Array is never flushed, and it is not GC'd since it's referenced in a class instance variable.

This change returns early in both event handlers if the debugger is not enabled. We also mark the utility methods in the debugger as private so they cannot be accessed outside of the class (and add data to chunks).

My first approach was to add the guard clause directly to `add_chunks` private method, which also fixes the leak; however, i changed to this strategy to save some CPU and memory building the data structures that aren't needed if debugging is disabled.