### PR TITLE
Avoid need for writable PK on update

### DIFF
--- a/lib/graphiti/request_validator.rb
+++ b/lib/graphiti/request_validator.rb
@@ -6,18 +6,18 @@ module Graphiti
       :deserialized_payload,
       to: :@validator
 
-    def initialize(root_resource, raw_params)
-      @validator = ValidatorFactory.create(root_resource, raw_params)
+    def initialize(root_resource, raw_params, action)
+      @validator = ValidatorFactory.create(root_resource, raw_params, action)
     end
 
     class ValidatorFactory
-      def self.create(root_resource, raw_params)
-        case raw_params["action"]
-        when "update" then
+      def self.create(root_resource, raw_params, action)
+        case action
+        when :update then
           RequestValidators::UpdateValidator
         else
           RequestValidators::Validator
-        end.new(root_resource, raw_params)
+        end.new(root_resource, raw_params, action)
       end
     end
   end

--- a/lib/graphiti/request_validators/validator.rb
+++ b/lib/graphiti/request_validators/validator.rb
@@ -3,10 +3,11 @@ module Graphiti
     class Validator
       attr_reader :errors
 
-      def initialize(root_resource, raw_params)
+      def initialize(root_resource, raw_params, action)
         @root_resource = root_resource
         @raw_params = raw_params
         @errors = Graphiti::Util::SimpleErrors.new(raw_params)
+        @action = action
       end
 
       def validate
@@ -68,6 +69,11 @@ module Graphiti
 
       def typecast_attributes(resource, attributes, payload_path)
         attributes.each_pair do |key, value|
+          # Only validate id if create action, otherwise it's only used for lookup
+          next if @action != :create &&
+            key == :id &&
+            resource.class.config[:attributes][:id][:writable] == false
+
           begin
             attributes[key] = resource.typecast(key, value, :writable)
           rescue Graphiti::Errors::UnknownAttribute

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -93,7 +93,7 @@ module Graphiti
       original = Graphiti.context[:namespace]
       begin
         Graphiti.context[:namespace] = action
-        ::Graphiti::RequestValidator.new(@resource, @payload.params).validate!
+        ::Graphiti::RequestValidator.new(@resource, @payload.params, action).validate!
         validator = persist {
           @resource.persist_with_relationships \
             @payload.meta(action: action),

--- a/lib/graphiti/runner.rb
+++ b/lib/graphiti/runner.rb
@@ -9,8 +9,7 @@ module Graphiti
       @query = query
       @action = action
 
-      validator = RequestValidator.new(jsonapi_resource, params)
-
+      validator = RequestValidator.new(jsonapi_resource, params, action)
       validator.validate!
 
       @deserialized_payload = validator.deserialized_payload

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -1754,7 +1754,7 @@ RSpec.describe "persistence" do
 
     it "raises appropriate error" do
       expect {
-        klass.build(payload)
+        klass.build(payload).save
       }.to(raise_error { |e|
         expect(e).to be_a Graphiti::Errors::InvalidRequest
         expect(e.errors.full_messages).to eq ["data.attributes.foo is an unknown attribute"]
@@ -1770,11 +1770,41 @@ RSpec.describe "persistence" do
 
     it "raises appropriate error" do
       expect {
-        klass.build(payload)
+        klass.build(payload).save
       }.to(raise_error { |e|
         expect(e).to be_a Graphiti::Errors::InvalidRequest
         expect(e.errors.full_messages).to eq ["data.attributes.foo cannot be written"]
       })
+    end
+  end
+
+  context "when given an unwritable id" do
+    before do
+      klass.attribute :id, :string, writable: false
+      payload[:data][:id] = "123"
+    end
+
+    context "and it is a create operation" do
+      it "works" do
+        instance = klass.build(payload)
+        expect {
+          instance.save
+        }.to raise_error(Graphiti::Errors::InvalidRequest, /data.attributes.id/)
+      end
+    end
+
+    context "and it is an update operation" do
+      let!(:record) do
+        PORO::Employee.create(id: 123, first_name: "asdf")
+      end
+
+      it "works" do
+        instance = klass.find(payload)
+        expect {
+          expect(instance.update_attributes).to eq(true)
+        }.to change { klass.find(payload).data.first_name }
+          .from("asdf").to("Jane")
+      end
     end
   end
 
@@ -1786,7 +1816,7 @@ RSpec.describe "persistence" do
 
     it "raises helpful error" do
       expect {
-        klass.build(payload)
+        klass.build(payload).save
       }.to(raise_error { |e|
         expect(e).to be_a Graphiti::Errors::InvalidRequest
         expect(e.errors.full_messages).to eq ["data.attributes.foo should be type integer"]


### PR DESCRIPTION
There's some larger refactoring needed but this is the simplest possible
fix for the issue. There are three overall problems with the validator:

* Called for read operations, but meant to validate writes. I'm not sure
why this was ever the case, perhaps to eventually validate reads as
well.
* Called in multiple places (proxy and runner)
* References `params[:action]`, which couples us to Rails

So the ideal refactoring would be to only call the validator within
`ResourceProxy#save`, which addresses all the above.

The problem is one specific test looks at the metadata of a sideposted
resource (occasionally it's helpful to see things like "what parent
object is sideposting me"). Because read operations would go through the
validator and `id` would be typecast, this test now fails because it
sees `id` as a string instead of an integer, because it is no longer
being typecast.

I think I'm fine just updating the spec, but again this PR is to do the
simplest thing possible. So I instead added the very specific logic "if
validating id, and not a create operation, AND id is not writable, don't
attempt to typecast". The larger refactoring can come later.

Finally, the other future refactoring would be to avoid merging `id`
into `attributes` when not a create operation. Part of the issue here is
the deserializer is called even on reads (per above), which complicates
things further. So a good future approach would be to only call the
validator within `ResourceProxy#save`, then address deserialization
separately afterwards.

Fixes https://github.com/graphiti-api/graphiti/issues/264
See also: https://github.com/graphiti-api/graphiti/pull/265