### PR TITLE
Ensure scope override is honored on update/destroy

### DIFF
--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -118,6 +118,7 @@ module Graphiti
     end
 
     def destroy
+      data
       transaction_response = @resource.transaction do
         metadata = {method: :destroy}
         model = @resource.destroy(@query.filters[:id], metadata)
@@ -135,6 +136,7 @@ module Graphiti
     end
 
     def update_attributes
+      data
       save(action: :update)
     end
 

--- a/lib/graphiti/version.rb
+++ b/lib/graphiti/version.rb
@@ -1,3 +1,3 @@
 module Graphiti
-  VERSION = "1.2.21"
+  VERSION = "1.2.22"
 end

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -32,6 +32,40 @@ RSpec.describe "persistence" do
     expect(employee.data.first_name).to eq("Jane")
   end
 
+  describe 'updating' do
+    let!(:employee) { PORO::Employee.create(first_name: 'asdf') }
+
+    before do
+      payload[:data][:id] = employee.id.to_s
+    end
+
+    describe 'with scope override' do
+      it 'is honored' do
+        employee = klass.find(payload, { type: 'foo' })
+        expect {
+          employee.update_attributes
+        }.to raise_error(Graphiti::Errors::RecordNotFound)
+      end
+    end
+  end
+
+  describe 'destroying' do
+    let!(:employee) { PORO::Employee.create(first_name: 'asdf') }
+
+    before do
+      payload[:data][:id] = employee.id.to_s
+    end
+
+    describe 'with scope override' do
+      it 'is honored' do
+        employee = klass.find(payload, { type: 'foo' })
+        expect {
+          employee.destroy
+        }.to raise_error(Graphiti::Errors::RecordNotFound)
+      end
+    end
+  end
+
   describe "overrides" do
     before do
       klass.class_eval do


### PR DESCRIPTION
If you were passing a scope override for an update or destroy operation,
that scope wouldn't be properly honored. This PR ensures an error will
be correctly thrown if no record is found.

The downside is we look up the record twice, now, but I think we should
get a fix in ASAP.