### PR TITLE
Bail out if trying to filter by a nil id

### DIFF
--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -366,6 +366,20 @@ module Graphiti
       end
     end
 
+    class UndefinedIDLookup < Base
+      def initialize(resource_class)
+        @resource_class = resource_class
+      end
+
+      def message
+        <<~MSG
+          Tried to resolve #{@resource_class} with an :id filter, but the filter was nil.
+          This can result in unscoping a query, which can cause incorrect values to be
+          returned which may or may not bypass standard access controls.
+        MSG
+      end
+    end
+
     class UnknownAttribute < AttributeError
       def message
         "#{super}, but could not find an attribute with that name."

--- a/lib/graphiti/resource/interface.rb
+++ b/lib/graphiti/resource/interface.rb
@@ -23,6 +23,9 @@ module Graphiti
 
         # @api private
         def _find(params = {}, base_scope = nil)
+          guard_nil_id!(params[:data])
+          guard_nil_id!(params)
+
           id = params[:data].try(:[], :id) || params.delete(:id)
           params[:filter] ||= {}
           params[:filter][:id] = id if id
@@ -50,6 +53,13 @@ module Graphiti
             unless allow_request?(path, params, context_namespace)
               raise Errors::InvalidEndpoint.new(self, path, context_namespace)
             end
+          end
+        end
+
+        def guard_nil_id!(params)
+          return unless params
+          if params.key?(:id) && params[:id].nil?
+            raise Errors::UndefinedIDLookup.new(self)
           end
         end
       end

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -542,6 +542,37 @@ if ENV["APPRAISAL_INITIALIZED"]
           expect(salary.base_rate).to eq(15.0)
           expect(salary.overtime_rate).to eq(30.0)
         end
+
+        context "when the association is null" do
+          let(:payload) do
+            {
+              data: {
+                type: "employees",
+                attributes: {
+                  first_name: "Joe",
+                  last_name: "Smith",
+                  age: 30
+                },
+                relationships: {
+                  salary: {
+                    data: {
+                      type: "salaries",
+                      id: nil
+                    }
+                  }
+                }
+              }
+            }
+          end
+
+          let!(:existing_salary) { Salary.create(base_rate: 1, overtime_rate: 2) }
+
+          it "blows up" do
+            expect {
+              do_create(payload)
+            }.to raise_error(Graphiti::Errors::UndefinedIDLookup)
+          end
+        end
       end
 
       context "for existing records" do

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -32,16 +32,16 @@ RSpec.describe "persistence" do
     expect(employee.data.first_name).to eq("Jane")
   end
 
-  describe 'updating' do
-    let!(:employee) { PORO::Employee.create(first_name: 'asdf') }
+  describe "updating" do
+    let!(:employee) { PORO::Employee.create(first_name: "asdf") }
 
     before do
       payload[:data][:id] = employee.id.to_s
     end
 
-    describe 'with scope override' do
-      it 'is honored' do
-        employee = klass.find(payload, { type: 'foo' })
+    describe "with scope override" do
+      it "is honored" do
+        employee = klass.find(payload, {type: "foo"})
         expect {
           employee.update_attributes
         }.to raise_error(Graphiti::Errors::RecordNotFound)
@@ -49,16 +49,16 @@ RSpec.describe "persistence" do
     end
   end
 
-  describe 'destroying' do
-    let!(:employee) { PORO::Employee.create(first_name: 'asdf') }
+  describe "destroying" do
+    let!(:employee) { PORO::Employee.create(first_name: "asdf") }
 
     before do
       payload[:data][:id] = employee.id.to_s
     end
 
-    describe 'with scope override' do
-      it 'is honored' do
-        employee = klass.find(payload, { type: 'foo' })
+    describe "with scope override" do
+      it "is honored" do
+        employee = klass.find(payload, {type: "foo"})
         expect {
           employee.destroy
         }.to raise_error(Graphiti::Errors::RecordNotFound)


### PR DESCRIPTION
If we are trying to filter a resource by an id attribute but that
attribute is nil, we should raise an error. If we allow the resource
resolution to continue, the result will be an empty "where" clause and
taking the first result. This is a problem when sending `null` as the
relationship ID on a CREATE or UPDATE, as it would just associate
(and update!) the first record returned by the unscoped where clause.

We should probably have a check further up the stack as well in the
request validator or similar, but this at least puts a quick stop to the
issue and blows up these invalid requests while we take time to make a
more pleasant experience for API consumers.