### PR TITLE
fixes ruby 2.7 kwargs usage warnings

### DIFF
--- a/lib/graphiti/hash_renderer.rb
+++ b/lib/graphiti/hash_renderer.rb
@@ -45,10 +45,10 @@ module Graphiti
       {}.tap do |hash|
         hash[:data] = if serializers.is_a?(Array)
           serializers.map do |s|
-            s.to_hash(opts)
+            s.to_hash(**opts)
           end
         else
-          serializers.to_hash(opts)
+          serializers.to_hash(**opts)
         end
       end
     end

--- a/lib/graphiti/request_validators/validator.rb
+++ b/lib/graphiti/request_validators/validator.rb
@@ -51,7 +51,7 @@ module Graphiti
           relationships: relationships
         }
 
-        Graphiti::Util::RelationshipPayload.iterate(opts) do |x|
+        Graphiti::Util::RelationshipPayload.iterate(**opts) do |x|
           sideload_def = x[:sideload]
 
           unless sideload_def.writable?

--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -129,7 +129,7 @@ module Graphiti
         def get_attr(name, flag, opts = {})
           defaults = {request: false}
           opts = defaults.merge(opts)
-          new.get_attr(name, flag, opts)
+          new.get_attr(name, flag, **opts)
         end
 
         def abstract_class?
@@ -247,7 +247,7 @@ module Graphiti
 
       def get_attr!(name, flag, options = {})
         options[:raise_error] = true
-        get_attr(name, flag, options)
+        get_attr(name, flag, **options)
       end
 
       def get_attr(name, flag, request: false, raise_error: false)

--- a/lib/graphiti/serializer.rb
+++ b/lib/graphiti/serializer.rb
@@ -22,8 +22,8 @@ module Graphiti
       end
     end
 
-    def as_jsonapi(*)
-      super.tap do |hash|
+    def as_jsonapi(kwargs = {})
+      super(**kwargs).tap do |hash|
         strip_relationships!(hash) if strip_relationships?
         add_links!(hash)
       end

--- a/lib/graphiti/util/attribute_check.rb
+++ b/lib/graphiti/util/attribute_check.rb
@@ -44,7 +44,7 @@ module Graphiti
           Graphiti::Errors::UnknownAttribute
 
         if raise_error?(opts[:exists])
-          raise error_class.new(resource, name, flag, opts)
+          raise error_class.new(resource, name, flag, **opts)
         else
           false
         end

--- a/lib/graphiti/util/persistence.rb
+++ b/lib/graphiti/util/persistence.rb
@@ -211,7 +211,7 @@ class Graphiti::Util::Persistence
       relationships: @relationships
     }.merge(only: only, except: except)
 
-    Graphiti::Util::RelationshipPayload.iterate(opts) do |x|
+    Graphiti::Util::RelationshipPayload.iterate(**opts) do |x|
       yield x
     end
   end

--- a/spec/resource_proxy_spec.rb
+++ b/spec/resource_proxy_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Graphiti::ResourceProxy do
-  let(:instance) { described_class.new(double, double, double, {}) }
+  let(:instance) { described_class.new(double, double, double, **{}) }
   describe "pagination" do
     subject { instance.pagination }
     it "is a pagination delegate" do


### PR DESCRIPTION
fixes several warnings when using ruby version 2.7.0. 

a sample warning below:
> graphiti/lib/graphiti/resource/configuration.rb:132: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
>graphiti/lib/graphiti/resource/configuration.rb:253: warning: The called method `get_attr' is defined here


[more information about this ruby 2.7.0 warning can be read here](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#:~:text=In%20Ruby%202.7%2C%20keyword%20arguments%20can%20use%20non%2DSymbol%20keys.&text=If%20a%20method%20accepts%20both,non%2DSymbol%20keys%20are%20allowed.)