### PR TITLE
adapter support for non sql based databases

### DIFF
--- a/lib/graphiti/adapters/abstract.rb
+++ b/lib/graphiti/adapters/abstract.rb
@@ -400,6 +400,9 @@ module Graphiti
         raise "you must override #destroy in an adapter subclass"
       end
 
+      def close
+      end
+
       def self.numerical_operators
         [:eq, :not_eq, :gt, :gte, :lt, :lte].freeze
       end

--- a/lib/graphiti/adapters/abstract.rb
+++ b/lib/graphiti/adapters/abstract.rb
@@ -1,6 +1,9 @@
 module Graphiti
   module Adapters
     class Abstract
+      require "graphiti/adapters/persistence/associations.rb"
+      include Graphiti::Adapters::Persistence::Associations
+
       attr_reader :resource
 
       def initialize(resource)
@@ -401,6 +404,10 @@ module Graphiti
       end
 
       def close
+      end
+
+      def persistence_attributes(persistance, attributes)
+        attributes
       end
 
       def self.numerical_operators

--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -297,6 +297,10 @@ module Graphiti
         model_instance
       end
 
+      def close
+        ActiveRecord::Base.clear_active_connections!
+      end
+
       private
 
       def column_for(scope, name)

--- a/lib/graphiti/adapters/persistence/associations.rb
+++ b/lib/graphiti/adapters/persistence/associations.rb
@@ -1,0 +1,72 @@
+module Graphiti
+  module Adapters
+    module Persistence
+      module Associations
+        def process_belongs_to(persistence, attributes)
+          parents = [].tap do |processed|
+            persistence.iterate(only: [:polymorphic_belongs_to, :belongs_to]) do |x|
+              begin
+                id = x.dig(:attributes, :id)
+                x[:object] = x[:resource]
+                  .persist_with_relationships(x[:meta], x[:attributes], x[:relationships])
+                processed << x
+              rescue Graphiti::Errors::RecordNotFound
+                path = "relationships/#{x.dig(:meta, :jsonapi_type)}"
+                raise Graphiti::Errors::RecordNotFound.new(x[:sideload].name, id, path)
+              end
+            end
+          end
+
+          update_foreign_key_for_parents(parents, attributes)
+          parents
+        end
+
+        def process_has_many(persistence, caller_model)
+          [].tap do |processed|
+            persistence.iterate(except: [:polymorphic_belongs_to, :belongs_to]) do |x|
+              update_foreign_key(caller_model, x[:attributes], x)
+
+              x[:object] = x[:resource]
+                .persist_with_relationships(x[:meta], x[:attributes], x[:relationships], caller_model, x[:foreign_key])
+
+              processed << x
+            end
+          end
+        end
+
+        def update_foreign_key_for_parents(parents, attributes)
+          parents.each do |x|
+            update_foreign_key(x[:object], attributes, x)
+          end
+        end
+
+        # The child's attributes should be modified to nil-out the
+        # foreign_key when the parent is being destroyed or disassociated
+        #
+        # This is not the case for HABTM, whose "foreign key" is a join table
+        def update_foreign_key(parent_object, attrs, x)
+          return if x[:sideload].type == :many_to_many
+
+          if [:destroy, :disassociate].include?(x[:meta][:method])
+            if x[:sideload].polymorphic_has_one? || x[:sideload].polymorphic_has_many?
+              attrs[:"#{x[:sideload].polymorphic_as}_type"] = nil
+            end
+            attrs[x[:foreign_key]] = nil
+            update_foreign_type(attrs, x, null: true) if x[:is_polymorphic]
+          else
+            if x[:sideload].polymorphic_has_one? || x[:sideload].polymorphic_has_many?
+              attrs[:"#{x[:sideload].polymorphic_as}_type"] = parent_object.class.name
+            end
+            attrs[x[:foreign_key]] = parent_object.send(x[:primary_key])
+            update_foreign_type(attrs, x) if x[:is_polymorphic]
+          end
+        end
+
+        def update_foreign_type(attrs, x, null: false)
+          grouping_field = x[:sideload].parent.grouper.field_name
+          attrs[grouping_field] = null ? nil : x[:sideload].group_name
+        end
+      end
+    end
+  end
+end

--- a/lib/graphiti/delegates/pagination.rb
+++ b/lib/graphiti/delegates/pagination.rb
@@ -6,7 +6,7 @@ module Graphiti
       end
 
       def links?
-        @proxy.query.pagination_links?
+        @proxy.query.pagination_links? && @proxy.data.present?
       end
 
       def links

--- a/lib/graphiti/scope.rb
+++ b/lib/graphiti/scope.rb
@@ -45,9 +45,7 @@ module Graphiti
         resolve_sideload = -> {
           Graphiti.context = graphiti_context
           sideload.resolve(results, q, parent_resource)
-          if concurrent && defined?(ActiveRecord)
-            ActiveRecord::Base.clear_active_connections!
-          end
+          @resource.adapter.close if concurrent
         }
         if concurrent
           promises << Concurrent::Promise.execute(&resolve_sideload)

--- a/spec/delegates/pagination_spec.rb
+++ b/spec/delegates/pagination_spec.rb
@@ -4,6 +4,16 @@ RSpec.describe Graphiti::Delegates::Pagination do
   include_context "pagination_context"
   let(:instance) { described_class.new(proxy) }
 
+  describe "#links?" do
+    context "with empty data" do
+      before { allow(proxy).to receive(:data).and_return([]) }
+
+      it "returns false" do
+        expect(instance.links?).to eq(false)
+      end
+    end
+  end
+
   describe "#links" do
     subject { instance.links }
     before do

--- a/spec/scope_spec.rb
+++ b/spec/scope_spec.rb
@@ -93,6 +93,28 @@ RSpec.describe Graphiti::Scope do
         instance.resolve_sideloads(results)
       end
 
+      context "with concurrency" do
+        before { allow(Graphiti.config).to receive(:concurrency).and_return(true) }
+
+        it "closes db connections" do
+          allow(sideload).to receive(:resolve).and_return(sideload)
+
+          expect(resource.adapter).to receive(:close)
+          instance.resolve_sideloads(results)
+        end
+      end
+
+      context "without concurrency" do
+        before { allow(Graphiti.config).to receive(:concurrency).and_return(false) }
+
+        it "does not close db connection" do
+          allow(sideload).to receive(:resolve).and_return(sideload)
+
+          expect(resource.adapter).not_to receive(:close)
+          instance.resolve_sideloads(results)
+        end
+      end
+
       context "but no parents were found" do
         let(:results) { [] }
 


### PR DESCRIPTION
[slack reference](https://graphiti-api.slack.com/archives/C5A4UEMGS/p1588869748275000)

While trying to adapt Graphiti to neo4j database via its [OGM](https://github.com/neo4jrb/activegraph). We found that activerecord is engraved into Graphiti in some places, and we would need a cleaner separation between graphiti and activerecord to make Graphiti easy to use for other type of databases.

I have tried to separate the AR dependancy from some modules and I have moved it back to adapter classes. It would be much easier to use Graphiti with non relational databases if relationalDB concept such as foreign_key etc are placed in adapters.

I have not added test cases related to the changes to avoid rework in case of some changing feedback, once the initial review of changes are done I can add tests related to the changes.