### PR TITLE
fixes #280 duplicate count query issue

### DIFF
--- a/lib/graphiti/delegates/pagination.rb
+++ b/lib/graphiti/delegates/pagination.rb
@@ -53,7 +53,7 @@ module Graphiti
       def item_count
         begin
           return @item_count if @item_count
-          @item_count = @proxy.resource.stat(:total, :count).call(@proxy.scope.unpaginated_object, :total)
+          @item_count = item_count_from_proxy || item_count_from_stats
           unless @item_count.is_a?(Numeric)
             raise TypeError, "#{@proxy.resource}.stat(:total, :count) returned an invalid value #{@item_count}"
           end
@@ -66,6 +66,15 @@ module Graphiti
           @item_count = 0
         end
         @item_count
+      end
+
+      def item_count_from_proxy
+        @proxy.stats.dig(:total, :count)
+      end
+
+      def item_count_from_stats
+        stats = Stats::Payload.new(@proxy.resource, @proxy.query, @proxy.scope.unpaginated_object, @proxy.data)
+        stats.calculate_stat(:total, @proxy.resource.stat(:total, :count))
       end
 
       def current_page

--- a/lib/graphiti/stats/payload.rb
+++ b/lib/graphiti/stats/payload.rb
@@ -31,14 +31,17 @@ module Graphiti
             stats[name] = {}
 
             each_calculation(name, calculation) do |calc, function|
-              args = [@scope, name]
-              args << @resource.context if function.arity >= 3
-              args << @data if function.arity == 4
-
-              stats[name][calc] = function.call(*args)
+              stats[name][calc] = calculate_stat(name, function)
             end
           end
         end
+      end
+
+      def calculate_stat(name, function)
+        args = [@scope, name]
+        args << @resource.context if function.arity >= 3
+        args << @data if function.arity == 4
+        function.call(*args)
       end
 
       private

--- a/spec/delegates/pagination_spec.rb
+++ b/spec/delegates/pagination_spec.rb
@@ -147,8 +147,8 @@ RSpec.describe Graphiti::Delegates::Pagination do
     end
 
     context "with stats[total]=count in request" do
-      let(:params) { super().merge!(stats: { total: 'count' }) }
-      let(:stats_map) { { total: { count: expected_item_count } } }
+      let(:params) { super().merge!(stats: {total: "count"}) }
+      let(:stats_map) { {total: {count: expected_item_count}} }
       before { allow(proxy).to receive(:stats).and_return(stats_map) }
 
       it "depends on proxy to get count" do

--- a/spec/stats/payload_spec.rb
+++ b/spec/stats/payload_spec.rb
@@ -27,4 +27,40 @@ RSpec.describe Graphiti::Stats::Payload do
       })
     end
   end
+
+  describe "#calculate_stat" do
+    let(:dsl) { Class.new(Graphiti::Resource).new }
+    let(:name) { :total }
+    let(:function) { dsl.stat(name, :count) }
+    let(:expected_count) { 108 }
+
+    context "with default scope and name argument" do
+      it "returns correct count" do
+        expect_any_instance_of(Graphiti::Adapters::Abstract).to receive(:count).with(scope, :total).and_return(expected_count)
+        expect(instance.calculate_stat(name, function)).to eq expected_count
+      end
+    end
+
+    context "with additional resource-context argument" do
+      let(:function) { double(arity: 3) }
+      let(:context) { double.as_null_object }
+      before { allow(dsl).to receive(:context).and_return(context) }
+
+      it "returns correct count" do
+        expect(function).to receive(:call).with(scope, name, context).and_return(expected_count)
+        expect(instance.calculate_stat(name, function)).to eq expected_count
+      end
+    end
+
+    context "with additional resource-context and data argument" do
+      let(:function) { double(arity: 4) }
+      let(:context) { double.as_null_object }
+      before { allow(dsl).to receive(:context).and_return(context) }
+
+      it "returns correct count" do
+        expect(function).to receive(:call).with(scope, name, context, data).and_return(expected_count)
+        expect(instance.calculate_stat(name, function)).to eq expected_count
+      end
+    end
+  end
 end


### PR DESCRIPTION
fixes #280 duplicate count query issue

Before sample request logs

```
Started GET "/api/v1/departments?page[size]=1&page[number]=2&stats[total]=count" for ::1 at 2020-09-25 06:41:13 +0530
  [1m[35m (0.2ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
  ↳ /Users/hardik_joshi/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/activerecord-5.2.3/lib/active_record/log_subscriber.rb:98
Processing by DepartmentsController#index as JSONAPI
  Parameters: {"page"=>{"size"=>"1", "number"=>"2"}, "stats"=>{"total"=>"count"}}
  [1m[36mDepartment Load (0.2ms)[0m  [1m[34mSELECT  "departments".* FROM "departments" LIMIT ? OFFSET ?[0m  [["LIMIT", 1], ["OFFSET", 1]]
  ↳ /Users/hardik_joshi/work/graphiti/graphiti/lib/graphiti/adapters/active_record.rb:222
  [1m[35m (0.3ms)[0m  [1m[34mSELECT COUNT(DISTINCT "departments"."id") FROM "departments"[0m
  ↳ /Users/hardik_joshi/work/graphiti/graphiti/lib/graphiti/adapters/active_record.rb:194
  [1m[35mCACHE  (0.0ms)[0m  [1m[34mSELECT COUNT(DISTINCT "departments"."id") FROM "departments"[0m
  ↳ /Users/hardik_joshi/work/graphiti/graphiti/lib/graphiti/adapters/active_record.rb:194
[37m[0m
[1m[32m=== Graphiti Debug[0m
[1m[32mTop Level Data Retrieval (+ sideloads):[0m
[1m[36mDepartmentResource.all({:page=>{:size=>"1", :number=>"2"}, :stats=>{:total=>"count"}})[0m
[1m[35mTook: 6.08ms[0m
[37m[0m
[1m[32m=== Graphiti Debug[0m
[1m[32mRendering:[0m
[1m[35mTook: 1843178.6ms[0m
Completed 200 OK in 1843235ms (Views: 1843184.4ms | ActiveRecord: 1.1ms)
```

After sample request logs

```
Started GET "/api/v1/departments?page[size]=1&page[number]=2&stats[total]=count" for ::1 at 2020-09-25 10:28:20 +0530
  [1m[35m (0.4ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
  ↳ /Users/hardik_joshi/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/activerecord-5.2.3/lib/active_record/log_subscriber.rb:98
Processing by DepartmentsController#index as JSONAPI
  Parameters: {"page"=>{"size"=>"1", "number"=>"2"}, "stats"=>{"total"=>"count"}}
  [1m[36mDepartment Load (0.2ms)[0m  [1m[34mSELECT  "departments".* FROM "departments" LIMIT ? OFFSET ?[0m  [["LIMIT", 1], ["OFFSET", 1]]
  ↳ /Users/hardik_joshi/work/graphiti/graphiti/lib/graphiti/adapters/active_record.rb:222
  [1m[35m (0.2ms)[0m  [1m[34mSELECT COUNT(DISTINCT "departments"."id") FROM "departments"[0m
  ↳ /Users/hardik_joshi/work/graphiti/graphiti/lib/graphiti/adapters/active_record.rb:194
[37m[0m
[1m[32m=== Graphiti Debug[0m
[1m[32mTop Level Data Retrieval (+ sideloads):[0m
[1m[36mDepartmentResource.all({:page=>{:size=>"1", :number=>"2"}, :stats=>{:total=>"count"}})[0m
[1m[35mTook: 13.4ms[0m
[37m[0m
[1m[32m=== Graphiti Debug[0m
[1m[32mRendering:[0m
[1m[35mTook: 41.3ms[0m
Completed 200 OK in 241ms (Views: 55.0ms | ActiveRecord: 1.0ms)
```

`SELECT COUNT(DISTINCT "departments"."id") FROM "departments"` is fired twice before this fix, and only one time after the fix.