### PR TITLE
Fixes #282: multiple errors when model name contains "Resource"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Features:
 - [157](https://github.com/graphiti-api/graphiti/pull/157) Using attribute option schema: false.
   This option is default true and is not effected by only and except options. (@zeisler)
 
+Fixes:
+- [282] Support model names including "Resource"
+
 ## 1.1.0
 
 Features:

--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -149,14 +149,14 @@ module Graphiti
 
         def infer_type
           if name.present?
-            name.demodulize.gsub("Resource", "").underscore.pluralize.to_sym
+            name.demodulize.sub(/.*\KResource/, "").underscore.pluralize.to_sym
           else
             :undefined_jsonapi_type
           end
         end
 
         def infer_model
-          name&.gsub("Resource", "")&.safe_constantize
+          name&.sub(/.*\KResource/, "")&.safe_constantize
         end
 
         # @api private


### PR DESCRIPTION
For example with the model `ResourcePool`.
The fix is to identify the model based on the resource name such as
"MyModelResource", substracting only the LAST occurence of the string
"Resource".