### PR TITLE
Fix total count not working with some base_scope when using Active Record

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -191,7 +191,7 @@ module Graphiti
       # (see Adapters::Abstract#count)
       def count(scope, attr)
         if attr.to_sym == :total
-          scope.distinct.count
+          scope.distinct.count(:all)
         else
           scope.distinct.count(attr)
         end

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -1500,5 +1500,20 @@ if ENV["APPRAISAL_INITIALIZED"]
         expect(included("states").length).to eq(1)
       end
     end
+
+    context "when base_scope is set" do
+      before do
+        Legacy::AuthorResource.class_eval do
+          def base_scope
+            Legacy::Author.select("*", "id as id_1")
+          end
+        end
+      end
+
+      it "can query stats total count" do
+        do_index({stats: {total: "count"}})
+        expect(d.map(&:id)).to eq([author1.id, author2.id])
+      end
+    end
   end
 end

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -1501,7 +1501,7 @@ if ENV["APPRAISAL_INITIALIZED"]
       end
     end
 
-    context "when base_scope is set" do
+    context "when select statement is specified" do
       before do
         Legacy::AuthorResource.class_eval do
           def base_scope


### PR DESCRIPTION
This is my attempt to fix issue #287.

It may be related to how the Active Record's `count` method changed in Rails version 4. TLDR is we should use `Model.count(:all)` instead of `Model.count`:
- https://github.com/rails/rails/issues/15138
- https://stackoverflow.com/questions/18252570/rails-difference-between-model-count-and-model-countall

P/S: This is one of my first pull requests to any repositories other than my own, so forgive me if I missed anything.

If you think my pull request does help, you may label this pull request as `hacktoberfest-accepted` since I'm participating in hacktoberfest event this month.

The last thing is thanks for creating an awesome library, I've been currently using it in production and it works really well!