### PR TITLE
Do not generate many_to_many filter when it exists

### DIFF
--- a/lib/graphiti/sideload/many_to_many.rb
+++ b/lib/graphiti/sideload/many_to_many.rb
@@ -36,9 +36,12 @@ class Graphiti::Sideload::ManyToMany < Graphiti::Sideload::HasMany
     self_ref = self
     fk_type = parent_resource_class.attributes[:id][:type]
     fk_type = :hash if polymorphic?
-    resource_class.filter inverse_filter, fk_type do
-      eq do |scope, value|
-        self_ref.belongs_to_many_filter(scope, value)
+    # Do not recreate if filter already exists
+    unless resource_class.config[:filters].has_key?(inverse_filter.to_sym)
+      resource_class.filter inverse_filter, fk_type do
+        eq do |scope, value|
+          self_ref.belongs_to_many_filter(scope, value)
+        end
       end
     end
   end

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -1314,18 +1314,20 @@ if ENV["APPRAISAL_INITIALIZED"]
 
       context "when filter already exists and it is wrong" do
         let(:existing_filter) {
-          {:aliases=>[:author_id],
-           :name=>:author_id,
-           :type=>:integer_id,
-           :allow=>nil,
-           :deny=>nil,
-           :single=>false,
-           :dependencies=>nil,
-           :required=>false,
-           :operators=>
-             {:eq=>nil, :not_eq=>nil, :gt=>nil, :gte=>nil, :lt=>nil, :lte=>nil},
-                :allow_nil=>false,
-              :deny_empty=>false}
+          {
+            aliases: [:author_id],
+            name: :author_id,
+            type: :integer_id,
+            allow: nil,
+            deny: nil,
+            single: false,
+            dependencies: nil,
+            required: false,
+            operators:
+              {eq: nil, not_eq: nil, gt: nil, gte: nil, lt: nil, lte: nil},
+            allow_nil: false,
+            deny_empty: false
+          }
         }
 
         before do


### PR DESCRIPTION
- Fixes an issue where we are unable to modify the generated filter
because it gets blown away by the generated filter.