### PR TITLE
Fix logger level check

### DIFF
--- a/lib/graphiti/configuration.rb
+++ b/lib/graphiti/configuration.rb
@@ -43,7 +43,7 @@ module Graphiti
         end
 
         if (logger = ::Rails.logger)
-          self.debug = logger.level.zero? && debug
+          self.debug = logger.debug? && debug
           Graphiti.logger = logger
         end
       end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -26,8 +26,10 @@ RSpec.describe Graphiti::Configuration do
 
   # FIXME: Deprecated
   describe "when rails is defined" do
+    let(:logger) { double('debug?': false) }
+
     let(:rails) do
-      double(root: Pathname.new("/foo/bar"), logger: OpenStruct.new(level: 1))
+      double(root: Pathname.new("/foo/bar"), logger: logger)
     end
 
     before do
@@ -51,9 +53,7 @@ RSpec.describe Graphiti::Configuration do
 
       # FIXME: Deprecated
       context "when rails logger is debug level" do
-        before do
-          rails.logger.level = 0
-        end
+        let(:logger) { double('debug?': true) }
 
         it { is_expected.to eq(true) }
       end


### PR DESCRIPTION
Use public method `#debug?` instead of checking the numeric
representation of logger level.

This fix compatibility issue with alternative loggers, see
rocketjob/semantic_logger#28.