### PR TITLE
Fix: Uncaught ActiveRecord::RecordInvalid error when saving new, invalid has_many or many_to_many associations

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -241,7 +241,16 @@ module Graphiti
             if association_type == :many_to_many &&
                 [:create, :update].include?(Graphiti.context[:namespace]) &&
                 !parent.send(association_name).exists?(child.id)
-              parent.send(association_name) << child
+              target = parent.send(association_name)
+              if child.persisted?
+                target << child
+              else
+                new_child = target.create(child.attributes)
+
+                child.instance_variables.each do |variable|
+                  new_child.instance_variable_set(variable, child.instance_variable_get(variable))
+                end
+              end
             else
               target = association.instance_variable_get(:@target)
               target |= [child]

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -700,7 +700,7 @@ if ENV["APPRAISAL_INITIALIZED"]
               positions: {
                 data: [
                   {type: "positions", 'temp-id': "pos1", method: "create"},
-                  {type: "positions", 'temp-id': "pos2", method: "create"},
+                  {type: "positions", 'temp-id': "pos2", method: "create"}
                 ]
               },
               teams: {


### PR DESCRIPTION
I discovered that validation errors were not coming through to the frontend when saving an invalid association on a `many_to_many` join; similar to (or the same as, I'm not sure): https://github.com/graphiti-api/graphiti/issues/198

The root cause was `parent.send(association_name) << child` in the ActiveRecord adaptor since this causes a `save!` operation which throws the `ActiveRecord::RecordInvalid` error, which is uncaught, causing the JSON API response to not contain relevant information as to what the validation error was; or in our use case, the error was caught by a global error handler and returned a non JSON API response.

To resolve the issue and allow validation errors to be returned as expected, create a new association and re-apply instance variables (`@_jsonapi_temp_id` at least is required for generating errors in [GraphitiErrors::Validation::Serializer](https://github.com/graphiti-api/graphiti_errors/blob/4e5341928b7fd39b26aacb544d833080f0f03441/lib/graphiti_errors/validation/serializer.rb#L119)

Simply rescuing the error doesn't work as the new association isn't maintained.


Note: Force push to squash troubleshooting commits into one neat commit