### PR TITLE
Add validation error on missing sidepost

### DIFF
--- a/lib/graphiti/adapters/persistence/associations.rb
+++ b/lib/graphiti/adapters/persistence/associations.rb
@@ -11,8 +11,16 @@ module Graphiti
                   .persist_with_relationships(x[:meta], x[:attributes], x[:relationships])
                 processed << x
               rescue Graphiti::Errors::RecordNotFound
-                path = "relationships/#{x.dig(:meta, :jsonapi_type)}"
-                raise Graphiti::Errors::RecordNotFound.new(x[:sideload].name, id, path)
+                if Graphiti.config.raise_on_missing_sidepost
+                  path = "relationships/#{x.dig(:meta, :jsonapi_type)}"
+                  raise Graphiti::Errors::RecordNotFound.new(x[:sideload].name, id, path)
+                else
+                  pointer = "data/relationships/#{x.dig(:meta, :jsonapi_type)}"
+                  object = Graphiti::Errors::NullRelation.new(id.to_s, pointer)
+                  object.errors.add(:base, :not_found, message: "could not be found")
+                  x[:object] = object
+                  processed << x
+                end
               end
             end
           end

--- a/lib/graphiti/configuration.rb
+++ b/lib/graphiti/configuration.rb
@@ -14,6 +14,7 @@ module Graphiti
     attr_accessor :pagination_links_on_demand
     attr_accessor :pagination_links
     attr_accessor :typecast_reads
+    attr_accessor :raise_on_missing_sidepost
 
     attr_reader :debug, :debug_models
 
@@ -29,6 +30,7 @@ module Graphiti
       @pagination_links_on_demand = false
       @pagination_links = false
       @typecast_reads = true
+      @raise_on_missing_sidepost = true
       self.debug = ENV.fetch("GRAPHITI_DEBUG", true)
       self.debug_models = ENV.fetch("GRAPHITI_DEBUG_MODELS", false)
 

--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -2,6 +2,21 @@ module Graphiti
   module Errors
     class Base < StandardError; end
 
+    class NullRelation
+      extend ActiveModel::Naming
+      attr_accessor :id, :errors, :pointer
+
+      def initialize(id, pointer)
+        @id = id
+        @pointer = pointer
+        @errors = ActiveModel::Errors.new(self)
+      end
+
+      def self.human_attribute_name(attr, options = {})
+        attr
+      end
+    end
+
     class AdapterNotImplemented < Base
       def initialize(adapter, attribute, method)
         @adapter = adapter


### PR DESCRIPTION
[This issue](https://github.com/graphiti-api/graphiti-rails/issues/65) raised the idea that we should be treating a missing sideposted record as a validation, not a 401.

In the course of this work I found [this older PR](https://github.com/graphiti-api/graphiti/pull/214), which initially raised the same point in [this comment](https://github.com/graphiti-api/graphiti/pull/214#issuecomment-597756121).

I very much agree that this should be a validation error, not a 401, but it breaks backwards compatibility. So, you can opt-in to this behavior with `Graphiti.config.raise_on_missing_sidepost = false`. We should consider this a best practice going forward and note it in the blog.