### PR TITLE
Sort remote resources in schema generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Features:
 
 Fixes:
 - [282] Support model names including "Resource"
+- [313](https://github.com/graphiti-api/graphiti/pull/313) Sort remote resources in schema generation
 
 ## 1.1.0
 

--- a/lib/graphiti/schema.rb
+++ b/lib/graphiti/schema.rb
@@ -25,7 +25,7 @@ module Graphiti
 
     def initialize(resources)
       @resources = resources.sort_by(&:name)
-      @remote_resources = resources.select(&:remote?)
+      @remote_resources = @resources.select(&:remote?)
       @local_resources = @resources - @remote_resources
     end
 

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -574,6 +574,20 @@ RSpec.describe Graphiti::Schema do
       end
     end
 
+    context "with multiple remote resources" do
+      let(:resources) { [position_resource, employee_resource] }
+
+      before do
+        employee_resource.remote = "http://foo.com"
+        position_resource.remote = "http://bar.com"
+      end
+
+      it "is added to the schema sorted by name" do
+        expect(schema[:resources].map { |resource| resource[:name] })
+          .to eq(["Schema::EmployeeResource", "Schema::PositionResource"])
+      end
+    end
+
     context "when sideload is single: true" do
       before do
         employee_resource.has_many :positions,


### PR DESCRIPTION
Remote resources are not ordered which causes the schema to randomly change depending on load order.