### PR TITLE
Support polymorphic includes

### DIFF
--- a/lib/graphiti/hash_renderer.rb
+++ b/lib/graphiti/hash_renderer.rb
@@ -2,7 +2,6 @@ module Graphiti
   module SerializableHash
     def to_hash(fields: nil, include: {}, name_chain: [], graphql: false)
       {}.tap do |hash|
-
         if fields
           fields_list = nil
 
@@ -16,11 +15,16 @@ module Graphiti
           end
         end
 
-        # polymorphic resources
-        if @resource.respond_to?(:type) && @resource.type != jsonapi_type
+        # polymorphic resources - merge the PARENT type
+        if @resource.polymorphic? && @resource.type != jsonapi_type
           if fields[@resource.type]
             fields_list ||= []
             fields_list |= fields[@resource.type]
+          end
+
+          if fields[jsonapi_type]
+            fields_list ||= []
+            fields_list |= fields[jsonapi_type]
           end
         end
 
@@ -28,22 +32,56 @@ module Graphiti
           name = graphql ? k.to_s.camelize(:lower).to_sym : k
           h[name] = instance_eval(&v)
         }
-        rels = @_relationships.select { |k, v| !!include[k] }
+
+        # The main logic here is just !!include[k]
+        # But we also have special on__<type>--<name> includes
+        # Where we only include when matching the polymorphic type
+        rels = @_relationships.select { |k, v|
+          if include[k]
+            true
+          else
+            included = false
+            include.keys.each do |key|
+              split = key.to_s.split(/^on__/)
+              if split.length > 1
+                requested_type, key = split[1].split("--")
+                if requested_type.to_sym == jsonapi_type
+                  included = k == key.to_sym
+                  break
+                end
+              end
+            end
+            included
+          end
+        }
+
         rels.each_with_object({}) do |(k, v), h|
+          nested_include = include[k]
+
+          # This logic only fires if it's a special on__<type>--<name> include
+          unless include.has_key?(k)
+            include.keys.each do |include_key|
+              if k == include_key.to_s.split("--")[1].to_sym
+                nested_include = include[include_key]
+                break
+              end
+            end
+          end
+
           serializers = v.send(:resources)
           name = graphql ? k.to_s.camelize(:lower) : k
           name_chain = name_chain.dup
           name_chain << k unless name_chain.last == k
           attrs[name.to_sym] = if serializers.is_a?(Array)
-            serializers.map do |rr| # use private method to avoid array casting
-              rr.to_hash(fields: fields, include: include[k], graphql: graphql, name_chain: name_chain)
+            serializers.map do |rr|
+              rr.to_hash(fields: fields, include: nested_include, graphql: graphql, name_chain: name_chain)
             end
           elsif serializers.nil?
             if @resource.class.sideload(k).type.to_s.include?("_many")
               []
             end
           else
-            serializers.to_hash(fields: fields, include: include[k], graphql: graphql, name_chain: name_chain)
+            serializers.to_hash(fields: fields, include: nested_include, graphql: graphql, name_chain: name_chain)
           end
         end
 

--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -96,7 +96,18 @@ module Graphiti
               sl_resource = resource_for_sideload(sideload)
               query_parents = parents + [self]
               sub_hash = sub_hash[:include] if sub_hash.key?(:include)
-              hash[key] = Query.new(sl_resource, @params, key, sub_hash, query_parents, :all)
+
+              # NB: To handle on__<type>--<name>
+              # A) relationship_name == :positions
+              # B) key == on__employees.positions
+              # This way A) ensures sideloads are resolved
+              # And B) ensures nested filters, sorts etc still work
+              relationship_name = sideload ? sideload.name : key
+              hash[relationship_name] = Query.new sl_resource,
+                @params,
+                key,
+                sub_hash,
+                query_parents, :all
             else
               handle_missing_sideload(key)
             end

--- a/lib/graphiti/resource/polymorphism.rb
+++ b/lib/graphiti/resource/polymorphism.rb
@@ -42,9 +42,14 @@ module Graphiti
         end
 
         def sideload(name)
-          sl = super
+          if (split_on = name.to_s.split(/^on__/)).length > 1
+            on_type, name = split_on[1].split("--").map(&:to_sym)
+          end
+
+          sl = super(name)
           if !polymorphic_child? && sl.nil?
             children.each do |c|
+              next if on_type && c.type != on_type
               break if (sl = c.sideloads[name])
             end
           end

--- a/lib/graphiti/schema.rb
+++ b/lib/graphiti/schema.rb
@@ -110,7 +110,7 @@ module Graphiti
           config[:default_page_size] = r.default_page_size
         end
 
-        if r.polymorphic?
+        if r.polymorphic? && !r.polymorphic_child?
           config[:polymorphic] = true
           config[:children] = r.children.map(&:name)
         end

--- a/spec/rendering_spec.rb
+++ b/spec/rendering_spec.rb
@@ -162,6 +162,55 @@ RSpec.describe "serialization" do
           end
         end
       end
+
+      context "when the relationship is to a polymorphic resource" do
+        before do
+          PORO::Visa.create employee_id: employee2.id, number: 1
+          gold = PORO::GoldVisa.create employee_id: employee2.id, number: 2
+          PORO::VisaReward.create visa_id: gold.id
+          PORO::Mastercard.create employee_id: employee2.id, number: 3
+          params[:include] = "credit_cards.on__gold_visas--visa_rewards"
+        end
+
+        # NB - both visa and gold visa support the relationship
+        # But we only see it on gold visas
+        it "respects type-specific includes" do
+          cards = json[1]["credit_cards"]
+          expect(cards[0].keys).to eq(%w[id number description visa_only_attr])
+          expect(cards[1].keys)
+            .to eq(%w[id number description visa_only_attr visa_rewards])
+          expect(cards[2].keys).to eq(%w[id number description])
+          expect(cards[1]["visa_rewards"]).to eq([{
+            "id" => "1",
+            "points" => nil
+          }])
+        end
+      end
+
+      context "and the top-level resource is polymorphic" do
+        before do
+          PORO::Visa.create employee_id: employee2.id, number: 1
+          gold = PORO::GoldVisa.create employee_id: employee2.id, number: 2
+          PORO::VisaReward.create visa_id: gold.id
+          PORO::Mastercard.create employee_id: employee2.id, number: 3
+        end
+
+        it "respects type-specific includes" do
+          proxy = PORO::CreditCardResource.all({
+            include: "on__gold_visas--visa_rewards"
+          })
+          json = JSON.parse(proxy.to_json)
+          cards = json["data"]
+          expect(cards[0].keys).to eq(%w[id number description visa_only_attr])
+          expect(cards[1].keys)
+            .to eq(%w[id number description visa_only_attr visa_rewards])
+          expect(cards[2].keys).to eq(%w[id number description])
+          expect(cards[1]["visa_rewards"]).to eq([{
+            "id" => "1",
+            "points" => nil
+          }])
+        end
+      end
     end
 
     context "when sparse fields" do
@@ -203,7 +252,7 @@ RSpec.describe "serialization" do
           context "when deeply nested, with multiple objects per type" do
             before do
               params[:include] = "positions.department.positions.department"
-              params[:fields] = {:"positions.department.positions.department" => "description"}
+              params[:fields] = {"positions.department.positions.department": "description"}
               dept = PORO::Department.create(name: "anotherdept")
               PORO::Position.create \
                 employee_id: employee1.id,

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -722,12 +722,15 @@ RSpec.describe Graphiti::Schema do
     end
 
     context "when polymorphic resources" do
-      let(:resources) { [PORO::CreditCardResource] }
+      let(:resources) { [PORO::CreditCardResource, PORO::VisaResource] }
 
-      it "generates a polymorphic schema for the resource" do
+      it "generates a polymorphic schema for the parent but not the children" do
         expect(schema[:resources][0][:polymorphic]).to eq(true)
         expect(schema[:resources][0][:children])
           .to eq(["PORO::VisaResource", "PORO::GoldVisaResource", "PORO::MastercardResource"])
+        visa = schema[:resources].find { |r| r[:name] == "PORO::VisaResource" }
+        expect(visa).to_not have_key(:polymorphic)
+        expect(visa).to_not have_key(:children)
       end
     end
 

--- a/spec/sideloading_spec.rb
+++ b/spec/sideloading_spec.rb
@@ -369,7 +369,9 @@ RSpec.describe "sideloading" do
         "visa_rewards" => {"meta" => {"included" => false}}
       })
       expect(included[1].jsonapi_type).to eq("mastercards")
-      expect(included[1].relationships).to be_nil
+      expect(included[1].relationships).to eq({
+        "commercials" => {"meta" => {"included" => false}}
+      })
     end
 
     context "when defaults" do
@@ -518,7 +520,9 @@ RSpec.describe "sideloading" do
           "visa_rewards" => {"meta" => {"included" => false}}
         })
         expect(included[1].jsonapi_type).to eq("mastercards")
-        expect(included[1].relationships).to be_nil
+        expect(included[1].relationships).to eq({
+          "commercials" => {"meta" => {"included" => false}}
+        })
         expect(included[2].jsonapi_type).to eq("paypals")
         expect(included[2].relationships).to be_nil
       end


### PR DESCRIPTION
Currently for polymorphic resources we just check if the include is supported - if it is, render it. For instance in the sample app
`Epic` is a type of `Task` and it's the only one with the `milestones` relationship. So `/tasks?include=milestones` works like
you'd think.

The issue is if both `Feature` and `Epic` support the `milestones` relationship (or if all types do via the parent resource), you can't conditionally request milestones just for epics. Enter this PR.

We introduce a special `on__<type>--<name>` syntax to conditionally include based on type, e.g. `?include=on__epics--milestones`. We can now support the use case. Note the syntax here is ugly, but we're tied to a finite set of supported characters according to the JSON:API spec.

In practice I view this as a kind of internal API for supporting GQL requests, so I'm only testing the hash renderer. I don't really want to advertise it unless we get requests to support it for jsonapi.

Note we're only doing this for includes, not fields. For fields we can reference the jsonapi type as normal and this would only be an issue if double-listing the same entities as multiple levels of the graph. Maybe we support this one day, but for now I'd like to limit the complexity/feature to just this case.

Finally - yes, the hash renderer is getting pretty ugly. Hands a little tied by the way jsonapi-rb works. I think we're nearing max ugliness and may also improve performance by writing our own (still needs to use serialization logic from jsonapi-rb), but holding off for now.