### PR TITLE
Raise error when unreadable attribute in GQL context

### DIFF
--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -2,6 +2,17 @@ module Graphiti
   module Errors
     class Base < StandardError; end
 
+    class UnreadableAttribute < Base
+      def initialize(resource_class, name)
+        @resource_class = resource_class
+        @name = name
+      end
+
+      def message
+        "#{@resource_class}: Requested field #{@name}, but not authorized to read it"
+      end
+    end
+
     class NullRelation
       extend ActiveModel::Naming
       attr_accessor :id, :errors, :pointer

--- a/lib/graphiti/util/serializer_attributes.rb
+++ b/lib/graphiti/util/serializer_attributes.rb
@@ -56,16 +56,21 @@ module Graphiti
         method_name = @attr[:readable]
         instance = @resource.new
         attribute = @name.to_s
+        resource_class = @resource
 
         -> {
           method = instance.method(method_name)
-          if method.arity.zero?
+          result = if method.arity.zero?
             instance.instance_eval(&method_name)
           elsif method.arity == 1
             instance.instance_exec(@object, &method)
           else
             instance.instance_exec(@object, attribute, &method)
           end
+          if Graphiti.context[:graphql] && !result
+            raise ::Graphiti::Errors::UnreadableAttribute.new(resource_class, attribute)
+          end
+          result
         }
       end
 

--- a/spec/fields_spec.rb
+++ b/spec/fields_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe "fields" do
           expect(attributes.keys).to_not include("salary")
         end
       end
+
+      context "and running in GraphQL context" do
+        it "raises error" do
+          expect {
+            Graphiti.with_context ctx, {} do
+              Graphiti.context[:graphql] = true
+              render
+              expect(attributes.keys).to_not include("salary")
+            end
+          }.to raise_error(::Graphiti::Errors::UnreadableAttribute, /salary/)
+        end
+      end
     end
 
     context "and the guard passes" do


### PR DESCRIPTION
Our current behavior is to simply not render the attribute when the
readable guard fails, but to adhere to the GQL spec we will instead
need to raise. There's a whole rat's nest of different auth patterns,
but this is the most straightforward thing for now.