### PR TITLE
Add `:self` to pagination links

### DIFF
--- a/lib/graphiti/delegates/pagination.rb
+++ b/lib/graphiti/delegates/pagination.rb
@@ -11,6 +11,7 @@ module Graphiti
 
       def links
         @links ||= {}.tap do |links|
+          links[:self] = pagination_link(current_page)
           links[:first] = pagination_link(1)
           links[:last] = pagination_link(last_page)
           links[:prev] = pagination_link(current_page - 1) unless current_page == 1

--- a/spec/delegates/pagination_spec.rb
+++ b/spec/delegates/pagination_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Graphiti::Delegates::Pagination do
       allow(instance).to receive(:item_count).and_return(current_per_page * total_pages)
     end
     it "generates pagination links" do
-      expect(subject).to include(:first, :next, :last, :prev)
+      expect(subject.keys).to match_array(%i[first next last prev self])
     end
     it "generates a link for the first page" do
       expect(subject[:first]).to eq pagination_link(1)
@@ -33,6 +33,9 @@ RSpec.describe Graphiti::Delegates::Pagination do
     end
     it "generates a link for the prev page" do
       expect(subject[:prev]).to eq pagination_link(prev_page)
+    end
+    it "generates a link for the current page" do
+      expect(subject[:self]).to eq pagination_link(current_page)
     end
     context "if on the first page" do
       let(:current_page) { 1 }


### PR DESCRIPTION
Hi there :)

Scratching my own itch because I needed this for a project.

`links[:self]` isn't a requirement for jsonapi, but [it is shown in examples](https://jsonapi.org/examples/#pagination).

Please let me know if any further changes/additional tests are necessary. I checked the changes against the Sinatra example app and it looked correct there.

Thanks!

<details><summary>screenshot</summary>
<img width="863" alt="Screenshot 2021-02-26 at 10 22 38" src="https://user-images.githubusercontent.com/353485/109288437-c2599400-781c-11eb-8169-c5aa02b015bb.png">
</details>
