### PR TITLE
Allow same name for attribute and relationship

### DIFF
--- a/lib/graphiti/renderer.rb
+++ b/lib/graphiti/renderer.rb
@@ -26,7 +26,11 @@ module Graphiti
     end
 
     def to_json
-      render(self.class.hash_renderer(@proxy)).to_json
+      as_json.to_json
+    end
+
+    def as_json
+      render(self.class.hash_renderer(@proxy))
     end
 
     def to_xml

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -47,6 +47,10 @@ module Graphiti
       Renderer.new(self, options).to_json
     end
 
+    def as_json(options = {})
+      Renderer.new(self, options).as_json
+    end
+
     def to_xml(options = {})
       Renderer.new(self, options).to_xml
     end

--- a/lib/graphiti/serializer.rb
+++ b/lib/graphiti/serializer.rb
@@ -12,13 +12,36 @@ module Graphiti
     # go through type checking/coercion
     class_attribute :attributes_applied_via_resource
     class_attribute :extra_attributes_applied_via_resource
+    class_attribute :relationship_condition_blocks
     self.attributes_applied_via_resource = []
     self.extra_attributes_applied_via_resource = []
+    # See #requested_relationships
+    self.relationship_condition_blocks ||= {}
 
     def self.inherited(klass)
       super
       klass.class_eval do
         extend JSONAPI::Serializable::Resource::ConditionalFields
+
+        # See #requested_relationships
+        def self.relationship(name, options = {}, &block)
+          super
+          field_condition_blocks.delete(name)
+          _register_condition(relationship_condition_blocks, name, options)
+        end
+
+        # NB - avoid clobbering includes when sparse fieldset
+        # https://github.com/jsonapi-rb/jsonapi-serializable/pull/102
+        #
+        # We also override this method to ensure attributes and relationships
+        # have separate condition blocks. This way an attribute and
+        # relationship can have the same name, and the attribute can be
+        # conditional without affecting the relationship.
+        def requested_relationships(fields)
+          @_relationships.select do |k, _|
+            _conditionally_included?(self.class.relationship_condition_blocks, k)
+          end
+        end
       end
     end
 
@@ -27,12 +50,6 @@ module Graphiti
         strip_relationships!(hash) if strip_relationships?
         add_links!(hash)
       end
-    end
-
-    # Temporary fix until fixed upstream
-    # https://github.com/jsonapi-rb/jsonapi-serializable/pull/102
-    def requested_relationships(fields)
-      @_relationships
     end
 
     # Allow access to resource methods

--- a/lib/graphiti/util/class.rb
+++ b/lib/graphiti/util/class.rb
@@ -20,6 +20,12 @@ module Graphiti
         split = namespace.split("::")
         split[0, split.length - 1].join("::")
       end
+
+      def self.graphql_type_name(name)
+        name.gsub("Resource", "")
+          .gsub("::", "") # remove modules
+          .gsub(".", "__") # remove remote resource .
+      end
     end
   end
 end

--- a/lib/graphiti/util/remote_serializer.rb
+++ b/lib/graphiti/util/remote_serializer.rb
@@ -44,6 +44,7 @@ module Graphiti
           model.delete_field(:_relationships)
           # If this isn't set, Array(resources) will return []
           # This is important, because jsonapi-serializable makes this call
+          # To see the test failure, remote resource position > department
           model.instance_variable_set(:@__graphiti_resource, 1)
           model.instance_variable_set(:@__graphiti_serializer, serializer)
         end

--- a/lib/graphiti/util/serializer_attributes.rb
+++ b/lib/graphiti/util/serializer_attributes.rb
@@ -20,14 +20,12 @@ module Graphiti
           @serializer.send(_method, @name, serializer_options, &proc)
         elsif @serializer.attribute_blocks[@name].nil?
           @serializer.send(_method, @name, serializer_options, &proc)
+        elsif @serializer.send(applied_method).include?(@name)
+          @serializer.field_condition_blocks[@name] = guard if guard?
         else
-          if @serializer.send(applied_method).include?(@name)
-            @serializer.field_condition_blocks[@name] = guard if guard?
-          else
-            inner = @serializer.attribute_blocks.delete(@name)
-            wrapped = wrap_proc(inner)
-            @serializer.send(_method, @name, serializer_options, &wrapped)
-          end
+          inner = @serializer.attribute_blocks.delete(@name)
+          wrapped = wrap_proc(inner)
+          @serializer.send(_method, @name, serializer_options, &wrapped)
         end
 
         existing = @serializer.send(applied_method)

--- a/spec/remote_resource_spec.rb
+++ b/spec/remote_resource_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "remote resources" do
       expect(model.to_h).to_not have_key(:_relationships)
     end
 
-    it "can serialize correctly" do
+    it "can serialize jsonapi correctly" do
       json = JSON.parse(query.to_jsonapi)
       data = json["data"][0]
       expect(data["id"]).to eq("123")
@@ -83,6 +83,18 @@ RSpec.describe "remote resources" do
         "full_name" => "Jane Doe"
       })
       expect(json["meta"]).to eq({})
+    end
+
+    it "can serialize flat json correctly" do
+      json = query.as_json
+      expect(json).to eq({
+        data: [{
+          id: "123",
+          last_name: "DOE",
+          full_name: "Jane Doe",
+          first_name: "Jane"
+        }]
+      })
     end
 
     context "when remote_base_url is set" do

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -955,7 +955,6 @@ RSpec.describe "serialization" do
             end
           end
 
-
           context "and the guard fails" do
             before do
               ctx.overridden = false


### PR DESCRIPTION
This was already possible unless the attribute was guarded, in which case the relationship would incorrectly share the same guard. This is a "bug" in jsonapi-rb, so we add to our existing hacks on top of that library pending an upstream fix.

In practice this is helpful for a GQL-specific federated attribute, which would share the same name as a relationship but be conditionally rendered only for GQL.