### PR TITLE
Auto-convert graphql_entrypoint on assignment

### DIFF
--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -28,6 +28,14 @@ module Graphiti
           end
         end
 
+        def graphql_entrypoint=(val)
+          if val
+            super(val.to_s.camelize(:lower).to_sym)
+          else
+            super
+          end
+        end
+
         # The .stat call stores a proc based on adapter
         # So if we assign a new adapter, reconfigure
         def adapter=(val)

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Graphiti::Resource do
           .to eq(Graphiti::Serializer)
         # This class has no name
         expect(klass.type).to eq(:undefined_jsonapi_type)
-        expect(klass.graphql_entrypoint).to eq(:undefined_jsonapi_types)
+        expect(klass.graphql_entrypoint).to eq(:undefinedJsonapiTypes)
       end
 
       it "inherits defaults" do
@@ -468,6 +468,13 @@ RSpec.describe Graphiti::Resource do
   describe "#adapter" do
     it "defaults" do
       expect(instance.adapter.class).to eq(Graphiti::Adapters::Abstract)
+    end
+  end
+
+  describe ".graphql_entrypoint" do
+    it "automatically converts to gql camelCase" do
+      klass.graphql_entrypoint = :exemplary_employees
+      expect(klass.graphql_entrypoint).to eq(:exemplaryEmployees)
     end
   end
 


### PR DESCRIPTION
When `self.graphql_entrypoint = :foo_bar` we'll autoconvert to `:fooBar`

Doing this at assignment time so we don't have to create a string and
camelize during serialization time.