### PR TITLE
polymorphic children + extra fields

### DIFF
--- a/lib/graphiti/extensions/extra_attribute.rb
+++ b/lib/graphiti/extensions/extra_attribute.rb
@@ -46,9 +46,12 @@ module Graphiti
               next false unless instance_exec(&options[:if])
             end
 
-            @extra_fields &&
+            (@extra_fields &&
               @extra_fields[@_type] &&
-              @extra_fields[@_type].include?(name)
+              @extra_fields[@_type].include?(name)) ||
+            (@extra_fields &&
+              @extra_fields[@resource] &&
+              @extra_fields[@resource].include?(name))
           }
 
           attribute name, if: allow_field, &blk


### PR DESCRIPTION
Hi there :)

Sort of an issue with a potential fix included, before I add tests and tidy it up if it's deemed relevant.

We're using polymorphism, imagine the following class with an extra field on the top level:
```
class ThingResource < ApplicationResource
  self.polymorphic = [
    'Things::RedThing',
    'Things::BlueThing'
  ]

  extra_attribute :type, :string
```

If I were to visit `example.com/api/things/1`, it could be a `RedThing` or `BlueThing` - I don't know which. 

But in the current implementation, `example.com/api/things/1?extra_fields[things]=type` wouldn't work, as the `@_type` var is the type of the child. I'd have to specify either `?extra_fields[red_thing]=type` or `?extra_fields[blue_thing]=type` to get past the guard clause.

If this scenario - and the potential fix - makes sense, I'll tidy it up and add tests
 