### PR TITLE
Allow access to extra_fields with polymorphic parent resource type

### DIFF
--- a/lib/graphiti/extensions/extra_attribute.rb
+++ b/lib/graphiti/extensions/extra_attribute.rb
@@ -46,9 +46,9 @@ module Graphiti
               next false unless instance_exec(&options[:if])
             end
 
-            @extra_fields &&
-              @extra_fields[@_type] &&
-              @extra_fields[@_type].include?(name)
+            next false unless @extra_fields
+
+            @extra_fields[@_type]&.include?(name) || @extra_fields[@resource&.type]&.include?(name)
           }
 
           attribute name, if: allow_field, &blk

--- a/spec/fixtures/poro.rb
+++ b/spec/fixtures/poro.rb
@@ -434,6 +434,10 @@ module PORO
     attribute :number, :integer
     attribute :description, :string
     filter :employee_id, :integer
+
+    extra_attribute :credit_score, :integer do
+      999
+    end
   end
 
   class VisaResource < CreditCardResource

--- a/spec/polymorphism_spec.rb
+++ b/spec/polymorphism_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "polymorphic resource behavior" do
   let(:resource) do
     Class.new(PORO::CreditCardResource) do
       self.polymorphic_child = false
+      self.type = "credit_cards"
     end
   end
 
@@ -253,6 +254,34 @@ RSpec.describe "polymorphic resource behavior" do
             }
           ])
         end
+      end
+    end
+  end
+
+  describe "accessing extra_fields" do
+    before do
+      params[:include] = "visa_rewards"
+    end
+
+    context "using the parent as key" do
+      before do
+        params[:extra_fields] = {credit_cards: "credit_score"}
+      end
+
+      it "displays the extra_field" do
+        render
+        expect(json["data"][0]["attributes"]).to include({"credit_score" => 999})
+      end
+    end
+
+    context "using the polymorphic child as key" do
+      before do
+        params[:extra_fields] = {visas: "credit_score"}
+      end
+
+      it "displays the extra_field" do
+        render
+        expect(json["data"][0]["attributes"]).to include({"credit_score" => 999})
       end
     end
   end


### PR DESCRIPTION
Following up from [this draft](https://github.com/graphiti-api/graphiti/pull/326) yesterday.

We're using polymorphism, imagine the following class with an extra field on the top level:
```
class ThingResource < ApplicationResource
  self.polymorphic = [
    'Things::RedThing',
    'Things::BlueThing'
  ]

  extra_attribute :type, :string
```

If I were to visit `example.com/api/things/1`, it could be a `RedThing` or `BlueThing` - I don't know which. 

But in the current implementation, `example.com/api/things/1?extra_fields[things]=type` wouldn't work, as the `@_type` var is the type of the child. I'd have to specify either `?extra_fields[red_thing]=type` or `?extra_fields[blue_thing]=type` to get past the guard clause.
