### PR TITLE
Propagate nested extra_fields to links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 Features:
+- [329](https://github.com/graphiti-api/graphiti/pull/329) Propagate `extra_fields` to related resource links.
 - [242](https://github.com/graphiti-api/graphiti/pull/242) Bump `jsonapi-renderer` to `~0.2.2` now that (https://github.com/jsonapi-rb/jsonapi-renderer/pull/36) is fixed.
 - [158](https://github.com/graphiti-api/graphiti/pull/158) Filters options `allow_nil: true`
   Option can be set at the resource level `Resource.filters_accept_nil_by_default = true`. 

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -136,6 +136,14 @@ module Graphiti
       base_filter(parents)
     end
 
+    def link_extra_fields
+      extra_fields_name = [association_name, resource.type].find { |param|
+        context.params.dig(:extra_fields, param)
+      }
+
+      {resource.type => context.params.dig(:extra_fields, extra_fields_name)} if extra_fields_name
+    end
+
     # The parent resource is a remote,
     # AND the sideload is a remote to the same endpoint
     def shared_remote?

--- a/lib/graphiti/util/link.rb
+++ b/lib/graphiti/util/link.rb
@@ -63,6 +63,10 @@ module Graphiti
             params[:filter] = @sideload.link_filter([@model])
           end
 
+          if (extra_fields = @sideload.link_extra_fields)
+            params[:extra_fields] ||= extra_fields
+          end
+
           @sideload.params_proc&.call(params, [@model], context)
         end
       end


### PR DESCRIPTION
Propagates the `extra_fields` attributes for a nested resource to the
relationship links created.

e.g. `GET http://example.com/books/1?extra_fields[authors]=biography`
should return a link to the `author` looking like
`http://example.com/authors/2?extra_fields[authors]=biography`,
propagating the `extra_fields` that apply for the nexted `authors`
resource.

Closes #328