### PR TITLE
Don't use ActiveModel::Naming unless defined

### DIFF
--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -14,7 +14,8 @@ module Graphiti
     end
 
     class NullRelation
-      extend ActiveModel::Naming
+      extend ActiveModel::Naming if defined? ActiveModel::Naming
+
       attr_accessor :id, :errors, :pointer
 
       def initialize(id, pointer)


### PR DESCRIPTION
ActiveModel is not a dependency of the project, so this allows the
library to be required without previously requiring active_model.

See https://github.com/graphiti-api/graphiti/issues/321