### PR TITLE
Use SimpleErrors instead of ActiveModel::Errors

### DIFF
--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -14,13 +14,12 @@ module Graphiti
     end
 
     class NullRelation
-      extend ActiveModel::Naming
       attr_accessor :id, :errors, :pointer
 
       def initialize(id, pointer)
         @id = id
         @pointer = pointer
-        @errors = ActiveModel::Errors.new(self)
+        @errors = Graphiti::Util::SimpleErrors.new(self)
       end
 
       def self.human_attribute_name(attr, options = {})

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -2446,7 +2446,7 @@ RSpec.describe "persistence" do
             errors = employee.data.classification.errors
             expect(errors.details).to eq(base: [{error: :not_found}])
             expect(errors.messages).to eq(base: ["could not be found"])
-            model = errors.instance_variable_get(:@base)
+            model = errors.instance_variable_get(:@target)
             expect(model.id).to eq("123")
             expect(model.pointer).to eq("data/relationships/classifications")
           end


### PR DESCRIPTION
ActiveModel is not a dependency of the project, so this allows the
library to be required without previously requiring active_model.

There was already an ActiveModel::Errors alternative in the graphiti
codebase.

See https://github.com/graphiti-api/graphiti/issues/321