### PR TITLE
Added any_required option to filter attributes

### DIFF
--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -690,7 +690,7 @@ module Graphiti
       end
 
       def message
-        "#{@resource.class.name}: One of the following filters must be passed in: #{@filters.keys.join(', ')}"
+        "#{@resource.class.name}: One of the following filters must be passed in: #{@filters.keys.join(", ")}"
       end
     end
 

--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -683,6 +683,17 @@ module Graphiti
       end
     end
 
+    class MissingAnyRequiredFilter < Base
+      def initialize(resource, filters)
+        @resource = resource
+        @filters = filters
+      end
+
+      def message
+        "#{@resource.class.name}: One of the following filters must be passed in: #{@filters.keys.join(', ')}"
+      end
+    end
+
     class ResourceNotFound < Base
       def initialize(resource_class, sideload_name, tried)
         @resource_class = resource_class

--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -23,6 +23,8 @@ module Graphiti
             end
 
             required = att[:filterable] == :required || !!opts[:required]
+            any_required = att[:filterable] == :any_required || !!opts[:any_required]
+
             config[:filters][name.to_sym] = {
               aliases: aliases,
               name: name.to_sym,
@@ -31,6 +33,7 @@ module Graphiti
               deny: opts[:deny],
               single: !!opts[:single],
               dependencies: opts[:dependent],
+              any_required: any_required,
               required: required,
               operators: operators.to_hash,
               allow_nil: opts.fetch(:allow_nil, filters_accept_nil_by_default),

--- a/lib/graphiti/scoping/filter.rb
+++ b/lib/graphiti/scoping/filter.rb
@@ -12,6 +12,12 @@ module Graphiti
           resource, missing_dependent_filters
       end
 
+      if any_required_filters.any?
+        unless present_any_required_filters.any?
+          raise Errors::MissingAnyRequiredFilter.new resource, any_required_filters
+        end
+      end
+
       each_filter do |filter, operator, value|
         @scope = filter_scope(filter, operator, value)
       end

--- a/lib/graphiti/scoping/filterable.rb
+++ b/lib/graphiti/scoping/filterable.rb
@@ -49,7 +49,7 @@ module Graphiti
     end
 
     def present_any_required_filters
-      any_required_filters.keys.intersection(filter_param.keys)
+      any_required_filters.keys.select { |name| filter_param.keys.include?(name) }
     end
 
     def any_required_filters

--- a/lib/graphiti/scoping/filterable.rb
+++ b/lib/graphiti/scoping/filterable.rb
@@ -47,5 +47,15 @@ module Graphiti
         v[:dependencies].present?
       end
     end
+
+    def present_any_required_filters
+      any_required_filters.keys.intersection(filter_param.keys)
+    end
+
+    def any_required_filters
+      resource.filters.select do |k, v|
+        v[:any_required].present?
+      end
+    end
   end
 end

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -1783,4 +1783,56 @@ RSpec.describe "filtering" do
       expect(records.map(&:id)).to eq([employee2.id])
     end
   end
+
+  context "when filter is any_required on .attribute" do
+    before do
+      resource.attribute :first_name, :string, filterable: :any_required
+      resource.attribute :last_name, :string, filterable: :any_required
+    end
+
+    context "when one is given in the request" do
+      before do
+        params[:filter] = {first_name: "Agatha"}
+      end
+
+      it "works" do
+        expect(records.map(&:id)).to eq([employee2.id])
+      end
+    end
+
+    context "when none are given in request" do
+      it "raises error" do
+        expect {
+          records
+        }.to raise_error(/One of the following filters must be passed in: first_name, last_name/)
+      end
+    end
+  end
+
+  context "when filter is any_required on .filter", focus: true do
+    before do
+      resource.config[:filters] = {}
+      resource.config[:attributes] = {}
+      resource.filter :first_name, :string, any_required: true
+      resource.filter :last_name, :string, any_required: true
+    end
+
+    context "when one is given in the request" do
+      before do
+        params[:filter] = {first_name: "Agatha"}
+      end
+
+      it "works" do
+        expect(records.map(&:id)).to eq([employee2.id])
+      end
+    end
+
+    context "when none are given in the request" do
+      it "raises error" do
+        expect {
+          records
+        }.to raise_error(/One of the following filters must be passed in: first_name, last_name/)
+      end
+    end
+  end
 end

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -1809,7 +1809,7 @@ RSpec.describe "filtering" do
     end
   end
 
-  context "when filter is any_required on .filter", focus: true do
+  context "when filter is any_required on .filter" do
     before do
       resource.config[:filters] = {}
       resource.config[:attributes] = {}


### PR DESCRIPTION
Added `any_required` option to filter attributes when we want one out of a set of attribute filters required. For example if we want to filter by either `employee_id` or `employee_uid`  field. This commit raises an error if one of the `any_required` attribute filters are not passed into the request.

Question: Should we only apply the first of any_required attributes? or go ahead and apply all as long as one is present. Currently it will apply all as long as one attribute `any_required` is present.