### PR TITLE
Add validation error when data/type missing

### DIFF
--- a/lib/graphiti/request_validators/update_validator.rb
+++ b/lib/graphiti/request_validators/update_validator.rb
@@ -26,17 +26,17 @@ module Graphiti
           [:data, :type],
           [:data, :id]
         ].each do |required_attr|
-          attribute_mismatch(required_attr) unless @raw_params.dig(*required_attr)
+          attribute_mismatch(required_attr) unless @params.dig(*required_attr)
         end
         errors.blank?
       end
 
       def payload_matches_endpoint?
-        unless @raw_params.dig(:data, :id) == @raw_params.dig(:filter, :id)
+        unless @params.dig(:data, :id) == @params.dig(:filter, :id)
           attribute_mismatch([:data, :id])
         end
 
-        meta_type = @raw_params.dig(:data, :type)
+        meta_type = @params.dig(:data, :type)
 
         # NOTE: calling #to_s and comparing 2 strings is slower than
         # calling #to_sym and comparing 2 symbols. But pre ruby-2.2

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -887,12 +887,12 @@ if ENV["APPRAISAL_INITIALIZED"]
                   code: "unprocessable_entity",
                   status: "422",
                   title: "Validation Error",
-                  detail: "translation missing: en.could not be found",
+                  detail: "could not be found",
                   source: {pointer: nil},
                   meta: {
                     relationship: {
                       attribute: "base",
-                      message: "translation missing: en.could not be found",
+                      message: "could not be found",
                       name: "classification",
                       type: "classifications",
                       id: "99999"

--- a/spec/request_validator_spec.rb
+++ b/spec/request_validator_spec.rb
@@ -54,6 +54,23 @@ RSpec.describe Graphiti::RequestValidator do
       end
     end
 
+    context "when missing type" do
+      let(:payload) do
+        {
+          data: {
+            attributes: {
+              first_name: "Jane"
+            }
+          }
+        }
+      end
+
+      it "adds corresponding error" do
+        expect(validate).to eq(false)
+        expect(instance.errors).to be_added(:'data.type', :missing)
+      end
+    end
+
     context "when a single level resource payload" do
       let(:payload) do
         {


### PR DESCRIPTION
Addresses https://github.com/graphiti-api/graphiti/issues/339

A few other things came up - one is that all requests, even reads, go
through the validator. Ideally the check is further upstream but I
tried to change the least amount of code while making this explicit.

The other is that I'm normalizing the params in the constructor, so
we can always deal with something normalized instead of worrying about
raw vs normalized. This has a downstream effect of changing the error
message for a Rails4-specific test you can see in the diff (if
anything, probably more correct now).