### PR TITLE
Add filter_group to schema/diffing

### DIFF
--- a/lib/graphiti/schema.rb
+++ b/lib/graphiti/schema.rb
@@ -99,6 +99,10 @@ module Graphiti
           relationships: relationships(r)
         }
 
+        if r.grouped_filters.any?
+          config[:filter_group] = r.grouped_filters
+        end
+
         if r.default_sort
           default_sort = r.default_sort.map { |s|
             {s.keys.first.to_s => s.values.first.to_s}
@@ -210,6 +214,10 @@ module Graphiti
           f[name] = config
         end
       end
+    end
+
+    def filter_group(resource)
+      resource.config[:grouped_filters]
     end
 
     def relationships(resource)

--- a/lib/graphiti/schema_diff.rb
+++ b/lib/graphiti/schema_diff.rb
@@ -30,6 +30,7 @@ module Graphiti
           compare_extra_attributes(r, new_resource)
           compare_sorts(r, new_resource)
           compare_filters(r, new_resource)
+          compare_filter_group(r, new_resource)
           compare_relationships(r, new_resource)
         end
       end
@@ -200,6 +201,27 @@ module Graphiti
 
         if new_filter[:guard] && !old_filter[:guard]
           @errors << "#{old_resource[:name]}: filter #{name.inspect} went from unguarded to guarded."
+        end
+      end
+    end
+
+    def compare_filter_group(old_resource, new_resource)
+      if new_resource[:filter_group]
+        if old_resource[:filter_group]
+          new_names = new_resource[:filter_group][:names]
+          old_names = old_resource[:filter_group][:names]
+          diff = new_names - old_names
+          if !diff.empty? && new_resource[:filter_group][:required] == :all
+            @errors << "#{old_resource[:name]}: all required filter group #{old_names.inspect} added #{"member".pluralize(diff.length)} #{diff.inspect}."
+          end
+
+          old_required = old_resource[:filter_group][:required]
+          new_required = new_resource[:filter_group][:required]
+          if old_required == :any && new_required == :all
+            @errors << "#{old_resource[:name]}: filter group #{old_names.inspect} moved from required: :any to required: :all"
+          end
+        else
+          @errors << "#{old_resource[:name]}: filter group #{new_resource[:filter_group][:names].inspect} was added."
         end
       end
     end

--- a/spec/schema_diff_spec.rb
+++ b/spec/schema_diff_spec.rb
@@ -728,6 +728,112 @@ RSpec.describe Graphiti::SchemaDiff do
       end
     end
 
+    context "when a filter group is added" do
+      before do
+        resource_b.filter_group [:first_name, :last_name], required: :any
+      end
+
+      it "returns error" do
+        expect(diff).to eq([
+          "SchemaDiff::EmployeeResource: filter group [:first_name, :last_name] was added."
+        ])
+      end
+    end
+
+    context "when a filter group is removed" do
+      before do
+        resource_b
+        resource_a.filter_group [:first_name, :last_name], required: :any
+      end
+
+      it "has no errors" do
+        expect(diff).to eq([])
+      end
+    end
+
+    context "when a filter group removes a name" do
+      before do
+        resource_b.filter_group [:last_name], required: :any
+        resource_a.filter_group [:first_name, :last_name], required: :any
+      end
+
+      it "has no errors" do
+        expect(diff).to eq([])
+      end
+    end
+
+    context "when a filter group adds a name" do
+      before do
+        resource_b.filter_group [:first_name, :last_name], required: required
+        resource_a.filter_group [:first_name], required: required
+      end
+
+      context "and any are required" do
+        let(:required) { :any }
+
+        it "has no errors" do
+          expect(diff).to eq([])
+        end
+      end
+
+      context "and all are required" do
+        let(:required) { :all }
+
+        it "returns error" do
+          expect(diff).to eq([
+            "SchemaDiff::EmployeeResource: all required filter group [:first_name] added member [:last_name]."
+          ])
+        end
+      end
+    end
+
+    context "when a filter group removes a name" do
+      before do
+        resource_b.filter_group [:first_name], required: required
+        resource_a.filter_group [:first_name, :last_name], required: required
+      end
+
+      context "and any are required" do
+        let(:required) { :any }
+
+        it "has no errors" do
+          expect(diff).to eq([])
+        end
+      end
+
+      context "and all are required" do
+        let(:required) { :all }
+
+        it "has no errors" do
+          expect(diff).to eq([])
+        end
+      end
+    end
+
+    context "when a filter group goes from :all to :any" do
+      before do
+        resource_b.filter_group [:first_name, :last_name], required: :any
+        resource_a.filter_group [:first_name, :last_name], required: :all
+      end
+
+      it "has no errors" do
+        expect(diff).to eq([])
+      end
+    end
+
+    context "when a filter group goes from :any to :all" do
+      before do
+        resource_b.filter_group [:first_name, :last_name], required: :all
+        resource_a.filter_group [:first_name, :last_name], required: :any
+      end
+
+      it "returns error" do
+        expect(diff).to eq([
+          "SchemaDiff::EmployeeResource: filter group [:first_name, :last_name] moved from required: :any to required: :all"
+        ])
+      end
+    end
+
     context "when filter goes unguarded to guarded" do
       before do
         resource_b.attribute :foo, :string, filterable: :admin?

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -475,6 +475,20 @@ RSpec.describe Graphiti::Schema do
       end
     end
 
+    context "when a filter group" do
+      before do
+        employee_resource.filter_group [:first_name, :last_name],
+          required: :any
+      end
+
+      it "is present in the schema" do
+        expect(schema[:resources][0][:filter_group]).to eq({
+          names: [:first_name, :last_name],
+          required: :any
+        })
+      end
+    end
+
     context "when the attribute is a string enum" do
       before do
         employee_resource.class_eval do


### PR DESCRIPTION
Scenarios for diffing are best outlined in the spec, but should be anything that would cause a client to break (for instance adding to the group when all are required).