### PR TITLE
Accommodate statistics in hash renderer

### DIFF
--- a/lib/graphiti/schema.rb
+++ b/lib/graphiti/schema.rb
@@ -96,7 +96,8 @@ module Graphiti
           extra_attributes: extra_attributes(r),
           sorts: sorts(r),
           filters: filters(r),
-          relationships: relationships(r)
+          relationships: relationships(r),
+          stats: stats(r)
         }
 
         if r.grouped_filters.any?
@@ -166,6 +167,14 @@ module Graphiti
         "guarded"
       else
         !!value
+      end
+    end
+
+    def stats(resource)
+      {}.tap do |stats|
+        resource.stats.each_pair do |name, config|
+          stats[name] = config.calculations.keys
+        end
       end
     end
 

--- a/lib/graphiti/schema_diff.rb
+++ b/lib/graphiti/schema_diff.rb
@@ -31,6 +31,7 @@ module Graphiti
           compare_sorts(r, new_resource)
           compare_filters(r, new_resource)
           compare_filter_group(r, new_resource)
+          compare_stats(r, new_resource)
           compare_relationships(r, new_resource)
         end
       end
@@ -222,6 +223,21 @@ module Graphiti
           end
         else
           @errors << "#{old_resource[:name]}: filter group #{new_resource[:filter_group][:names].inspect} was added."
+        end
+      end
+    end
+
+    def compare_stats(old_resource, new_resource)
+      old_resource[:stats].each_pair do |name, old_calculations|
+        new_calculations = new_resource[:stats][name]
+        if new_calculations
+          old_calculations.each do |calc|
+            unless new_calculations.include?(calc)
+              @errors << "#{old_resource[:name]}: calculation #{calc.inspect} was removed from stat #{name.inspect}."
+            end
+          end
+        else
+          @errors << "#{old_resource[:name]}: stat #{name.inspect} was removed."
         end
       end
     end

--- a/lib/graphiti/version.rb
+++ b/lib/graphiti/version.rb
@@ -1,3 +1,3 @@
 module Graphiti
-  VERSION = "1.2.35"
+  VERSION = "1.2.36"
 end

--- a/spec/rendering_spec.rb
+++ b/spec/rendering_spec.rb
@@ -486,9 +486,9 @@ RSpec.describe "serialization" do
         end
 
         it "is not returned" do
-          expect(json[:employees][0]).to eq({
+          expect(json[:employees][:nodes][0]).to eq({
             firstName: "John",
-            positions: [{title: "title1"}]
+            positions: {nodes: [{title: "title1"}]}
           })
         end
       end
@@ -500,10 +500,10 @@ RSpec.describe "serialization" do
         end
 
         it "is returned" do
-          expect(json[:employees][0]).to eq({
+          expect(json[:employees][:nodes][0]).to eq({
             id: employee1.id.to_s,
             firstName: "John",
-            positions: [{id: position1.id.to_s, title: "title1"}]
+            positions: {nodes: [{id: position1.id.to_s, title: "title1"}]}
           })
         end
       end
@@ -515,9 +515,9 @@ RSpec.describe "serialization" do
         end
 
         it "is not returned" do
-          expect(json[:employees][0]).to eq({
+          expect(json[:employees][:nodes][0]).to eq({
             firstName: "John",
-            positions: [{title: "title1"}]
+            positions: {nodes: [{title: "title1"}]}
           })
         end
       end
@@ -529,10 +529,10 @@ RSpec.describe "serialization" do
         end
 
         it "is returned" do
-          expect(json[:employees][0]).to eq({
+          expect(json[:employees][:nodes][0]).to eq({
             _type: "employees",
             firstName: "John",
-            positions: [{_type: "positions", title: "title1"}]
+            positions: {nodes: [{_type: "positions", title: "title1"}]}
           })
         end
       end
@@ -553,9 +553,9 @@ RSpec.describe "serialization" do
         end
 
         it "is camelized" do
-          expect(json[:employees][0]).to eq({
+          expect(json[:employees][:nodes][0]).to eq({
             firstName: "John",
-            positions: [{multiWord: "foo"}]
+            positions: {nodes: [{multiWord: "foo"}]}
           })
         end
       end
@@ -575,7 +575,8 @@ RSpec.describe "serialization" do
         end
 
         it "is camelized" do
-          expect(json[:employees][0][:importantPositions]).to eq([{
+          employee = json[:employees][:nodes][0]
+          expect(employee[:importantPositions][:nodes]).to eq([{
             rank: 1,
             title: "title1",
             importantDepartment: {

--- a/spec/schema_diff_spec.rb
+++ b/spec/schema_diff_spec.rb
@@ -891,6 +891,49 @@ RSpec.describe Graphiti::SchemaDiff do
       end
     end
 
+    context "when a stat is added" do
+      before do
+        resource_a.stat age: [:sum]
+      end
+
+      it { is_expected.to eq([]) }
+    end
+
+    context "when a stat is removed" do
+      before do
+        resource_a.stat age: [:sum]
+        resource_b.config[:stats].delete(:age)
+      end
+
+      it "returns error" do
+        expect(diff).to eq([
+          "SchemaDiff::EmployeeResource: stat :age was removed."
+        ])
+      end
+    end
+
+    context "when a calculation is added" do
+      before do
+        resource_a.stat age: [:sum]
+        resource_b.stat age: [:sum, :average]
+      end
+
+      it { is_expected.to eq([]) }
+    end
+
+    context "when a calculation is removed" do
+      before do
+        resource_a.stat age: [:sum, :average]
+        resource_b.stat age: [:sum]
+      end
+
+      it "returns error" do
+        expect(diff).to eq([
+          "SchemaDiff::EmployeeResource: calculation :average was removed from stat :age."
+        ])
+      end
+    end
+
     context "when relationship is added" do
       before do
         resource_b.has_many :positions, resource: position_resource

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe Graphiti::Schema do
               id: {},
               first_name: {}
             },
+            stats: {
+              total: [:count]
+            },
             filters: {
               id: {
                 type: "integer_id",
@@ -549,6 +552,19 @@ RSpec.describe Graphiti::Schema do
       it "returns :guarded, not the runtime method" do
         expect(schema[:resources][0][:extra_attributes][:net_sales][:readable])
           .to eq("guarded")
+      end
+    end
+
+    context "when an additional statistic/calculations" do
+      before do
+        employee_resource.stat age: [:average, :sum]
+      end
+
+      it "is added to the schema" do
+        expect(schema[:resources][0][:stats]).to eq({
+          total: [:count],
+          age: [:average, :sum]
+        })
       end
     end
 


### PR DESCRIPTION
* Add stats when requested
* Nest arrays within "nodes" key for GQL, so stats can be a sibling
* Don't render "nodes" when *only* stats requested & GQL
* Add stats to the schema/diffing

As with all hash rendering code, it's not lovely but gets the job done.

Did some benchmarking and if anything should render flat JSON very slightly faster; JSON:API performance was equivalent.