### PR TITLE
Fix schema diffing

### DIFF
--- a/lib/graphiti/version.rb
+++ b/lib/graphiti/version.rb
@@ -1,3 +1,3 @@
 module Graphiti
-  VERSION = "1.2.36"
+  VERSION = "1.2.37"
 end

--- a/spec/schema_diff_spec.rb
+++ b/spec/schema_diff_spec.rb
@@ -891,6 +891,18 @@ RSpec.describe Graphiti::SchemaDiff do
       end
     end
 
+    context "when the original schema does not have stats" do
+      before do
+        a[:resources].each { |r| r.delete(:stats) }
+      end
+
+      it "does not blow up" do
+        expect {
+          expect(diff).to eq([])
+        }.to_not raise_error
+      end
+    end
+
     context "when a stat is added" do
       before do
         resource_a.stat age: [:sum]
@@ -1193,7 +1205,7 @@ RSpec.describe Graphiti::SchemaDiff do
 
         it "returns error" do
           expect(diff).to eq([
-            'Endpoint "/schema_diff/employees" had incompatible sideload allowlist. Was [{:positions=>:department}, :same], now [:positions, :same].'
+            'Endpoint "/schema_diff/employees" had incompatible sideload allowlist. Was [{:positions=>"department"}, "same"], now ["positions", "same"].'
           ])
         end
       end


### PR DESCRIPTION
* When the prior schema didn't have "stats", we would blow up
* Because the prior schema is from a JSON file and the new one is
generated programmatically, we could enter scenarios incorrectly
comparing string values to symbol values. Always parse as JSON to avoid
this.