### PR TITLE
Use blank? instead of nil? for typecasting

### DIFF
--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -73,7 +73,7 @@ module Graphiti
         type_name = filters[name][:type]
       end
       type = Graphiti::Types[type_name]
-      return if value.nil? && type[:kind] != "array"
+      return if value.blank? && type[:kind] != "array"
       begin
         flag = :read if flag == :readable
         flag = :write if flag == :writable

--- a/spec/request_validator_spec.rb
+++ b/spec/request_validator_spec.rb
@@ -155,7 +155,41 @@ RSpec.describe Graphiti::RequestValidator do
           end
         end
 
-        context "and the typecast succeeds" do
+        context "and the typecast succeeds by empty string" do
+          before do
+            payload[:data][:attributes][:age] = ""
+          end
+
+          it "validates correctly" do
+            expect(validate).to eq true
+            expect(instance.errors).to be_blank
+          end
+
+          it "correctly typecasts the fields" do
+            validate
+
+            expect(instance.deserialized_payload.attributes[:age]).to be_blank
+          end
+        end
+
+        context "and the typecast succeeds by nil" do
+          before do
+            payload[:data][:attributes][:age] = nil
+          end
+
+          it "validates correctly" do
+            expect(validate).to eq true
+            expect(instance.errors).to be_blank
+          end
+
+          it "correctly typecasts the fields" do
+            validate
+
+            expect(instance.deserialized_payload.attributes[:age]).to be_blank
+          end
+        end
+
+        context "and the typecast succeeds by value" do
           before do
             payload[:data][:attributes][:age] = "34"
           end


### PR DESCRIPTION
If I want to update an `attribute :birth_date, :datetime` with `""` I run into a typecasting error.
For me such validation should be done later, if the filed is required...

In my opinion this JSON should be treated equally
```
{
  "value_1": "",
  "value_2": null
}
```

So start typecasting only if the value is not blank.