### PR TITLE
Make typecast on blank values configurable

### DIFF
--- a/lib/graphiti/request_validators/validator.rb
+++ b/lib/graphiti/request_validators/validator.rb
@@ -77,6 +77,10 @@ module Graphiti
             key == :id &&
             resource.class.config[:attributes][:id][:writable] == false
 
+          if resource.class.config[:attributes].has_key?(key)
+            next unless resource.class.config[:attributes][key][:typecast_on_blank] || value.present?
+          end
+
           begin
             attributes[key] = resource.typecast(key, value, :writable)
           rescue Graphiti::Errors::UnknownAttribute

--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -88,6 +88,7 @@ module Graphiti
           :attributes_sortable_by_default,
           :attributes_filterable_by_default,
           :attributes_schema_by_default,
+          :attributes_typecast_on_blank_by_default,
           :relationships_readable_by_default,
           :relationships_writable_by_default,
           :filters_accept_nil_by_default,
@@ -112,6 +113,7 @@ module Graphiti
           default(klass, :attributes_sortable_by_default, true)
           default(klass, :attributes_filterable_by_default, true)
           default(klass, :attributes_schema_by_default, true)
+          default(klass, :attributes_typecast_on_blank_by_default, true)
           default(klass, :relationships_readable_by_default, true)
           default(klass, :relationships_writable_by_default, true)
           default(klass, :filters_accept_nil_by_default, false)

--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -123,6 +123,7 @@ module Graphiti
           attribute_option(options, :sortable)
           attribute_option(options, :filterable)
           attribute_option(options, :schema, true)
+          attribute_option(options, :typecast_on_blank, true)
           options[:type] = type
           options[:proc] = blk
           config[:attributes][name] = options
@@ -144,7 +145,8 @@ module Graphiti
             readable: true,
             writable: false,
             sortable: false,
-            filterable: false
+            filterable: false,
+            typecast_on_blank: true
           }
           options = defaults.merge(options)
           attribute_option(options, :readable)

--- a/lib/graphiti/schema.rb
+++ b/lib/graphiti/schema.rb
@@ -145,7 +145,7 @@ module Graphiti
               writable: flag(config[:writable]),
               description: resource.attribute_description(name)
             }
-            attrs[name].merge!({ typecast_on_blank: flag(config[:typecast_on_blank]) }) unless config[:typecast_on_blank]
+            attrs[name].merge!({typecast_on_blank: flag(config[:typecast_on_blank])}) unless config[:typecast_on_blank]
           end
         end
       end
@@ -159,7 +159,7 @@ module Graphiti
             readable: flag(config[:readable]),
             description: resource.attribute_description(name)
           }
-          attrs[name].merge!({ typecast_on_blank: flag(config[:typecast_on_blank]) }) unless config[:typecast_on_blank]
+          attrs[name].merge!({typecast_on_blank: flag(config[:typecast_on_blank])}) unless config[:typecast_on_blank]
         end
       end
     end

--- a/lib/graphiti/schema.rb
+++ b/lib/graphiti/schema.rb
@@ -145,6 +145,7 @@ module Graphiti
               writable: flag(config[:writable]),
               description: resource.attribute_description(name)
             }
+            attrs[name].merge!({ typecast_on_blank: flag(config[:typecast_on_blank]) }) unless config[:typecast_on_blank]
           end
         end
       end
@@ -158,6 +159,7 @@ module Graphiti
             readable: flag(config[:readable]),
             description: resource.attribute_description(name)
           }
+          attrs[name].merge!({ typecast_on_blank: flag(config[:typecast_on_blank]) }) unless config[:typecast_on_blank]
         end
       end
     end

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -2248,6 +2248,42 @@ RSpec.describe "persistence" do
         expect(save("foo")).to eq("custom!")
       end
     end
+
+    # test for typecast_on_blank
+    context "when typecast_on_blank is false" do
+      before do
+        klass.attribute :age, :datetime, typecast_on_blank: false
+      end
+
+      it "works" do
+        expect(save("2021-03-25")).to eq("2021-03-25")
+      end
+
+      it "applies basic coercion" do
+        expect(save("2021-03-25")).to eq("2021-03-25")
+      end
+
+      it "raises error on single values" do
+        expect {
+          save("No datetieme")
+        }.to(raise_error { |e|
+          expect(e).to be_a Graphiti::Errors::InvalidRequest
+          expect(e.errors.full_messages).to eq ["data.attributes.age should be type datetime"]
+        })
+      end
+
+      it "raises no error on nils" do
+        expect {
+          save(nil)
+        }.to_not(raise_error(Graphiti::Errors::InvalidRequest))
+      end
+
+      it "raises no error on {}" do
+        expect {
+          save({})
+        }.to_not(raise_error(Graphiti::Errors::InvalidRequest))
+      end
+    end
   end
 
   describe "nested writes" do

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe Graphiti::Resource do
         expect(klass.attributes_sortable_by_default).to eq(true)
         expect(klass.attributes_filterable_by_default).to eq(true)
         expect(klass.attributes_schema_by_default).to eq(true)
+        expect(klass.attributes_typecast_on_blank_by_default).to eq(true)
         expect(klass.relationships_readable_by_default).to eq(true)
         expect(klass.relationships_writable_by_default).to eq(true)
         expect(klass.filters_accept_nil_by_default).to eq(false)
@@ -156,6 +157,7 @@ RSpec.describe Graphiti::Resource do
             self.attributes_sortable_by_default = false
             self.attributes_filterable_by_default = false
             self.attributes_schema_by_default = false
+            self.attributes_typecast_on_blank_by_default = false
             self.relationships_readable_by_default = false
             self.relationships_writable_by_default = false
             self.filters_accept_nil_by_default = true
@@ -172,6 +174,7 @@ RSpec.describe Graphiti::Resource do
           expect(klass.attributes_sortable_by_default).to eq(false)
           expect(klass.attributes_filterable_by_default).to eq(false)
           expect(klass.attributes_schema_by_default).to eq(false)
+          expect(klass.attributes_typecast_on_blank_by_default).to eq(false)
           expect(klass.relationships_readable_by_default).to eq(false)
           expect(klass.relationships_writable_by_default).to eq(false)
           expect(klass.filters_accept_nil_by_default).to eq(true)

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -25,11 +25,19 @@ RSpec.describe Graphiti::Schema do
                 readable: true,
                 writable: true,
                 description: "The employee's first name"
+              },
+              birthdate: {
+                type: "datetime",
+                readable: true,
+                writable: true,
+                typecast_on_blank: false,
+                description: "The employee's birth date"
               }
             },
             sorts: {
               id: {},
-              first_name: {}
+              first_name: {},
+              birthdate: {}
             },
             stats: {
               total: [:count]
@@ -43,6 +51,10 @@ RSpec.describe Graphiti::Schema do
                 type: "string",
                 operators: Graphiti::Adapters::Abstract.default_operators[:string].map(&:to_s)
               },
+              birthdate: {
+                type: "datetime",
+                operators: Graphiti::Adapters::Abstract.default_operators[:datetime].map(&:to_s)
+              },
               title: {
                 type: "string",
                 operators: Graphiti::Adapters::Abstract.default_operators[:string].map(&:to_s)
@@ -53,6 +65,12 @@ RSpec.describe Graphiti::Schema do
                 type: "float",
                 readable: true,
                 description: "The total value of the employee's sales"
+              },
+              anniversary: {
+                type: "datetime",
+                readable: true,
+                typecast_on_blank: false,
+                description: nil
               }
             },
             relationships: {
@@ -192,7 +210,10 @@ RSpec.describe Graphiti::Schema do
 
         attribute :first_name, :string, description: "The employee's first name"
         attribute :hidden_attribute, :string, schema: false
+        attribute :birthdate, :datetime, typecast_on_blank: false, description: "The employee's birth date"
+
         extra_attribute :net_sales, :float, description: "The total value of the employee's sales"
+        extra_attribute :anniversary, :datetime, typecast_on_blank: false
 
         filter :title, :string do
           eq do |scope, value|
@@ -539,6 +560,19 @@ RSpec.describe Graphiti::Schema do
       it "is readable" do
         expect(schema[:resources][0][:attributes][:hidden_attribute][:readable])
           .to eq(true)
+      end
+    end
+
+    context "when attribute changes to typecast_on_blank false" do
+      before do
+        employee_resource.class_eval do
+          attribute :frist_name, :string, typecast_on_blank: false
+        end
+      end
+
+      it "is readable" do
+        expect(schema[:resources][0][:attributes][:frist_name][:typecast_on_blank])
+          .to eq(false)
       end
     end
 


### PR DESCRIPTION
Example: `attribute :birthdate, :datetime, typecast_on_blank: false`
This option allows you to pass either `null` or `""` as value to set empty values without typecast.

The JSON should be treated equally:
```
{
  "value": "",
  "value": null
}
```