### PR TITLE
Fix many_to_many validation exception when sideposting

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -240,7 +240,8 @@ module Graphiti
           children.each do |child|
             if association_type == :many_to_many &&
                 [:create, :update].include?(Graphiti.context[:namespace]) &&
-                !parent.send(association_name).exists?(child.id)
+                !parent.send(association_name).exists?(child.id) &&
+                child.errors.blank?
               parent.send(association_name) << child
             else
               target = association.instance_variable_get(:@target)

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -781,7 +781,7 @@ if ENV["APPRAISAL_INITIALIZED"]
             },
             {
               type: "teams",
-              'temp-id': 'team1',
+              'temp-id': "team1",
               attributes: {name: "Team 1"}
             }
           ]


### PR DESCRIPTION
This fix is related to previously opened PR - https://github.com/graphiti-api/graphiti/pull/304.

When adding many_to_many related associations - for example `department.teams` << `new_team`, `save!` gets called on the related `new_team` and it throws a `ValidationError` that breaks the normal graphiti error handling. Prevent this by checking if the association is valid (has blank errors) before adding it.