### PR TITLE
Support page[offset] param

### DIFF
--- a/lib/graphiti/adapters/abstract.rb
+++ b/lib/graphiti/adapters/abstract.rb
@@ -244,14 +244,15 @@ module Graphiti
       # @param scope The scope object we are chaining
       # @param [Integer] current_page The current page number
       # @param [Integer] per_page The number of results per page
+      # @param [Integer] offset The offset to start from
       # @return the scope
       #
       # @example ActiveRecord default
       #   # via kaminari gem
-      #   def paginate(scope, current_page, per_page)
+      #   def paginate(scope, current_page, per_page, offset)
       #     scope.page(current_page).per(per_page)
       #   end
-      def paginate(scope, current_page, per_page)
+      def paginate(scope, current_page, per_page, offset)
         raise "you must override #paginate in an adapter subclass"
       end
 

--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -184,8 +184,11 @@ module Graphiti
       end
 
       # (see Adapters::Abstract#paginate)
-      def paginate(scope, current_page, per_page)
-        scope.page(current_page).per(per_page)
+      def paginate(scope, current_page, per_page, offset)
+        scope = scope.page(current_page) if current_page
+        scope = scope.per(per_page) if per_page
+        scope = scope.padding(offset) if offset
+        scope
       end
 
       # (see Adapters::Abstract#count)

--- a/lib/graphiti/adapters/null.rb
+++ b/lib/graphiti/adapters/null.rb
@@ -178,7 +178,7 @@ module Graphiti
       end
 
       # (see Adapters::Abstract#paginate)
-      def paginate(scope, current_page, per_page)
+      def paginate(scope, current_page, per_page, offset)
         scope
       end
 

--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -195,7 +195,7 @@ module Graphiti
               end
             elsif nested?(name)
               hash[name.to_s.split(".").last.to_sym] = value
-            elsif top_level? && [:number, :size].include?(name.to_sym)
+            elsif top_level? && [:number, :size, :offset].include?(name.to_sym)
               hash[name.to_sym] = value.to_i
             end
           end

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -360,7 +360,7 @@ module Legacy
       model.all
     end
 
-    def paginate(scope, a, b)
+    def paginate(scope, a, b, c)
       scope
     end
 

--- a/spec/fixtures/poro.rb
+++ b/spec/fixtures/poro.rb
@@ -98,6 +98,7 @@ module PORO
 
       def apply_pagination(records, params)
         return records unless params[:per]
+        records = records[params[:offset]..records.length] if params[:offset]
 
         start_at = (params[:page] - 1) * (params[:per])
         end_at = (params[:page] * params[:per]) - 1
@@ -292,8 +293,11 @@ module PORO
       {}
     end
 
-    def paginate(scope, current_page, per_page)
-      scope.merge!(page: current_page, per: per_page)
+    def paginate(scope, current_page, per_page, offset)
+      scope[:page] = current_page if current_page
+      scope[:per] = per_page if per_page
+      scope[:offset] = offset if offset
+      scope
     end
 
     def filter(scope, name, value)

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -66,6 +66,52 @@ RSpec.describe "pagination" do
     expect(ids).to eq([3, 4])
   end
 
+  context "when offset is given" do
+    before do
+      params[:page] = {offset: 2}
+    end
+
+    it "works" do
+      expect(ids).to eq([3, 4])
+    end
+
+    context "alongside page size" do
+      before do
+        params[:page][:size] = 1
+      end
+
+      it "works" do
+        expect(ids).to eq([3])
+      end
+    end
+
+    context "alongside page number" do
+      before do
+        params[:page][:number] = 2
+        params[:page][:size] = 1
+      end
+
+      it "works" do
+        expect(ids).to eq([4])
+      end
+    end
+
+    context "when a custom pagination override" do
+      before do
+        @spy = spy = {}
+        resource.paginate do |scope, current_page, per_page, ctx, offset|
+          spy[:value] = offset
+          scope
+        end
+      end
+
+      it "is yielded" do
+        ids
+        expect(@spy[:value]).to eq(2)
+      end
+    end
+  end
+
   # for metadata
   context "with page size 0" do
     it "should return empty array" do


### PR DESCRIPTION
Say you want to start paging, 10 per page, but skip the first 8 results. Previously we didn't support this since the page count isn't a multiple of the offset - now we can! This will serve not only as a useful param in-and-of-itself, but also serve as the basis for future cursor pagination, which will default to offset-based (as opposed to stable-id-based) by default.

Small notes on backwards compatibility. If you have a custom `paginate` override we can't change the existing order so it's:

```ruby
paginate do |scope, current_page, per_page, context, offset|
```

Instead of `offset, context`.

Also, we check the adapter arity to see if we should pass `offset` - this should accomodate existing non-AR adapters.