### PR TITLE
Don't blow up on invalid JSON

### DIFF
--- a/lib/graphiti/scoping/filter.rb
+++ b/lib/graphiti/scoping/filter.rb
@@ -171,14 +171,18 @@ module Graphiti
       type = Graphiti::Types[filter[:type]]
       array_or_string = [:string, :array].include?(type[:canonical_name])
       if (arr = value.scan(/\[.*?\]/)).present? && array_or_string
-        value = arr.map { |json|
-          begin
-            JSON.parse(json)
-          rescue
-            raise Errors::InvalidJSONArray.new(resource, value)
-          end
-        }
-        value = value[0] if value.length == 1
+        begin
+          value = arr.map { |json|
+            begin
+              JSON.parse(json)
+            rescue
+              raise Errors::InvalidJSONArray.new(resource, value)
+            end
+          }
+          value = value[0] if value.length == 1
+        rescue Errors::InvalidJSONArray => e
+          raise(e) if type[:canonical_name] == :array
+        end
       else
         value = parse_string_arrays(value, !!filter[:single])
       end

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -868,10 +868,18 @@ RSpec.describe "filtering" do
             params[:filter] = {foo: "[foo]"}
           end
 
-          it "works" do
-            expect {
-              records
-            }.to raise_error(Graphiti::Errors::InvalidJSONArray)
+          it "does not coerce" do
+            assert_filter_value(["[foo]"])
+          end
+
+          context "when single" do
+            before do
+              resource.filter :foo, single: true
+            end
+
+            it "does not cast to array" do
+              assert_filter_value("[foo]")
+            end
           end
         end
       end


### PR DESCRIPTION
We have a little helper that allows passing and parsing JSON strings. But that will blow up if passed invalid JSON, and the most common time that happens is when *the client isn't trying to pass json*. Consider:

```
?filter[name][eq]="[Setup]"
```

Prior to this commit, this request would blow up. But we shouldn't - the user is just asking for a string that has brackets in it.

This is only true if the type is `:string` - if the type is `:array` then yeah, we should blow up because they are trying to pass JSON and doing so incorrectly.