### PR TITLE
WIP: Allow an adapter to return a new object to replace the existing one.

### DIFF
--- a/lib/graphiti/adapters/abstract.rb
+++ b/lib/graphiti/adapters/abstract.rb
@@ -364,6 +364,8 @@ module Graphiti
             associate(parent, c, association_name, association_type)
           end
         end
+
+        parent
       end
 
       def associate(parent, child, association_name, association_type)
@@ -379,6 +381,8 @@ module Graphiti
         else
           parent.send(:"#{association_name}=", child)
         end
+
+        parent
       end
 
       def disassociate(parent, child, association_name, association_type)

--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -255,6 +255,8 @@ module Graphiti
         else
           super
         end
+
+        parent
       end
 
       def associate(parent, child, association_name, association_type)
@@ -265,6 +267,8 @@ module Graphiti
         else
           super
         end
+
+        parent
       end
 
       # When a has_and_belongs_to_many relationship, we don't have a foreign
@@ -275,6 +279,7 @@ module Graphiti
           parent.send(association_name).delete(child)
         end
         # Nothing to do in the else case, happened when we merged foreign key
+        parent
       end
 
       # (see Adapters::Abstract#create)


### PR DESCRIPTION
Opening a PR for discussion. I can refactor and add specs as advised if this is acceptable.

The intention of this change is to enable the use of an adapter that returns Dry::Structs, which are immutable. Associating parents or children needs to involve creation of a new object, rather than modifying the one passed in by reference as a parameter, which is currently what Graphiti expects. This small change has no functional effects on the rest of the code, but does allow adapters to return new objects.

The adapter at the moment is WIP too, but looks a bit like this:


```ruby
module Common
  module Graphiti
    module Adapters
      # An adapter to allow us to return entities from create and update operations
      # which are done using interactors. Reads for show and index operations
      # remain as active record.
      class EntityAdapter < ::Graphiti::Adapters::ActiveRecord
        # In order to keep the entities read-only we don't want to have setter methods,
        # which graphiti usually looks for with non-active-record objects. Instead,
        # we create new immutable Dry::Structs with the extra associations
        def associate(parent, child, association_name, association_type) # rubocop:disable ModularMonolith/Arguments
          new_parent = create_new_entity_with_child(parent, child, association_name, association_type)
          copy_across_graphiti_internal_instance_variables(parent, new_parent)
          new_parent
        end

        private

        def create_new_entity_with_child(parent, child, association_name, association_type)
          if association_type.in?([:belongs_to, :has_one])
            parent.class.new(parent.attributes.merge(association_name => child))
          else
            parent.class.new(parent.attributes.merge(association_name => child.to_a))
          end
        end

        def copy_across_graphiti_internal_instance_variables(parent, new_parent)
          %w(
            @__graphiti_serializer
            @__graphiti_resource
            @_jsonapi_temp_id
          ).each do |instance_variable_name|
            new_parent.instance_variable_set(instance_variable_name,
                                             parent.instance_variable_get(instance_variable_name))
          end
        end
      end
    end
  end
end
```