### PR TITLE
Fix paginate arity check

### DIFF
--- a/lib/graphiti/scoping/paginate.rb
+++ b/lib/graphiti/scoping/paginate.rb
@@ -33,12 +33,12 @@ module Graphiti
 
     # Apply default pagination proc via the Resource adapter
     def apply_standard_scope
-      arity = resource.adapter.method(:paginate)
+      meth = resource.adapter.method(:paginate)
 
-      if arity == 4 # backwards-compat
-        resource.adapter.paginate(@scope, number, size)
-      else
+      if meth.arity == 4 # backwards-compat
         resource.adapter.paginate(@scope, number, size, offset)
+      else
+        resource.adapter.paginate(@scope, number, size)
       end
     end
 

--- a/lib/graphiti/version.rb
+++ b/lib/graphiti/version.rb
@@ -1,3 +1,3 @@
 module Graphiti
-  VERSION = "1.2.43"
+  VERSION = "1.2.44"
 end


### PR DESCRIPTION
This was for backwards-compatibility with custom adapters not supporting offset, but our adapters do so we never ran into the issue.