### PR TITLE
Support cursor-based pagination

### DIFF
--- a/lib/graphiti/delegates/pagination.rb
+++ b/lib/graphiti/delegates/pagination.rb
@@ -14,9 +14,17 @@ module Graphiti
           links[:self] = pagination_link(current_page)
           links[:first] = pagination_link(1)
           links[:last] = pagination_link(last_page)
-          links[:prev] = pagination_link(current_page - 1) unless current_page == 1
-          links[:next] = pagination_link(current_page + 1) unless current_page == last_page
+          links[:prev] = pagination_link(current_page - 1) if has_previous_page?
+          links[:next] = pagination_link(current_page + 1) if has_next_page?
         end.select { |k, v| !v.nil? }
+      end
+
+      def has_next_page?
+        current_page != last_page && last_page.present?
+      end
+
+      def has_previous_page?
+        current_page != 1
       end
 
       private

--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -733,6 +733,12 @@ module Graphiti
       end
     end
 
+    class UnsupportedBeforeCursor < Base
+      def message
+        "Passing in page[before] and page[number] is not supported. Please create an issue if you need it!"
+      end
+    end
+
     class InvalidInclude < Base
       def initialize(resource, relationship)
         @resource = resource

--- a/lib/graphiti/hash_renderer.rb
+++ b/lib/graphiti/hash_renderer.rb
@@ -101,6 +101,10 @@ module Graphiti
           hash[:_type] = jsonapi_type.to_s
         end
 
+        if (fields_list || []).include?(:_cursor)
+          hash[:_cursor] = cursor
+        end
+
         if (fields_list || []).include?(:__typename)
           resource_class = @resource.class
           if polymorphic_subclass?
@@ -142,6 +146,10 @@ module Graphiti
       nodes = get_nodes(serializers, opts)
       add_nodes(hash, top_level_key, options, nodes, @graphql)
       add_stats(hash, top_level_key, options, @graphql)
+      if @graphql
+        add_page_info(hash, serializers, top_level_key, options)
+      end
+
       hash
     end
 
@@ -160,7 +168,7 @@ module Graphiti
 
     def get_nodes(serializers, opts)
       if serializers.is_a?(Array)
-        serializers.map do |s|
+        serializers.each_with_index.map do |s, index|
           s.to_hash(**opts)
         end
       else
@@ -189,6 +197,32 @@ module Graphiti
         else
           hash.merge!(options.slice(:meta))
         end
+      end
+    end
+
+    # NB - this is only for top-level right now
+    # The casing here is GQL-specific, we can update later if needed.
+    def add_page_info(hash, serializers, top_level_key, options)
+      if (fields = options[:fields].try(:[], :page_info))
+        info = {}
+
+        if fields.include?(:has_next_page)
+          info[:hasNextPage] = options[:proxy].pagination.has_next_page?
+        end
+
+        if fields.include?(:has_previous_page)
+          info[:hasPreviousPage] = options[:proxy].pagination.has_previous_page?
+        end
+
+        if fields.include?(:start_cursor)
+          info[:startCursor] = serializers.first.cursor
+        end
+
+        if fields.include?(:end_cursor)
+          info[:endCursor] = serializers.last.cursor
+        end
+
+        hash[top_level_key][:pageInfo] = info
       end
     end
   end

--- a/lib/graphiti/renderer.rb
+++ b/lib/graphiti/renderer.rb
@@ -66,6 +66,7 @@ module Graphiti
         options[:meta] ||= proxy.meta
         options[:meta][:stats] = proxy.stats unless proxy.stats.empty?
         options[:meta][:debug] = Debugger.to_a if debug_json?
+        options[:proxy] = proxy
 
         renderer.render(records, options)
       end

--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -28,11 +28,12 @@ module Graphiti
       serializer
     end
 
-    def decorate_record(record)
+    def decorate_record(record, index = nil)
       unless record.instance_variable_get(:@__graphiti_serializer)
         serializer = serializer_for(record)
         record.instance_variable_set(:@__graphiti_serializer, serializer)
         record.instance_variable_set(:@__graphiti_resource, self)
+        record.instance_variable_set(:@__graphiti_index, index) if index
       end
     end
 

--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -92,7 +92,8 @@ module Graphiti
           :relationships_writable_by_default,
           :filters_accept_nil_by_default,
           :filters_deny_empty_by_default,
-          :graphql_entrypoint
+          :graphql_entrypoint,
+          :cursor_paginatable
 
         class << self
           prepend Overrides

--- a/lib/graphiti/scope.rb
+++ b/lib/graphiti/scope.rb
@@ -85,8 +85,8 @@ module Graphiti
     # Used to ensure the resource's serializer is used
     # Not one derived through the usual jsonapi-rb logic
     def assign_serializer(records)
-      records.each do |r|
-        @resource.decorate_record(r)
+      records.each_with_index do |r, index|
+        @resource.decorate_record(r, index)
       end
     end
 

--- a/lib/graphiti/serializer.rb
+++ b/lib/graphiti/serializer.rb
@@ -45,6 +45,23 @@ module Graphiti
       end
     end
 
+    def cursor
+      starting_offset = 0
+      page_param = @proxy.query.pagination
+      if (page_number = page_param[:number])
+        page_size = page_param[:size] || @resource.default_page_size
+        starting_offset = (page_number - 1) * page_size
+      end
+
+      if (cursor = page_param[:after])
+        starting_offset = cursor[:offset]
+      end
+
+      current_offset = @object.instance_variable_get(:@__graphiti_index)
+      offset = starting_offset + current_offset + 1 # (+ 1 b/c o-base index)
+      Base64.encode64({offset: offset}.to_json).chomp
+    end
+
     def as_jsonapi(kwargs = {})
       super(**kwargs).tap do |hash|
         strip_relationships!(hash) if strip_relationships?

--- a/lib/graphiti/util/serializer_attributes.rb
+++ b/lib/graphiti/util/serializer_attributes.rb
@@ -28,6 +28,12 @@ module Graphiti
 
         existing = @serializer.send(applied_method)
         @serializer.send(:"#{applied_method}=", [@name] | existing)
+
+        @serializer.meta do
+          if !!@resource.try(:cursor_paginatable?) && !Graphiti.context[:graphql]
+            {cursor: cursor}
+          end
+        end
       end
 
       private

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -333,7 +333,7 @@ module Legacy
     attribute :float_age, :float
     attribute :decimal_age, :big_decimal
     attribute :active, :boolean
-    attribute :last_login, :datetime, only: [:filterable]
+    attribute :last_login, :datetime, only: [:filterable, :sortable]
     attribute :created_at, :datetime, only: [:filterable]
     attribute :created_at_date, :date, only: [:filterable]
     attribute :identifier, :uuid

--- a/spec/integration/rails/cursor_pagination_spec.rb
+++ b/spec/integration/rails/cursor_pagination_spec.rb
@@ -1,0 +1,132 @@
+if ENV["APPRAISAL_INITIALIZED"]
+  RSpec.describe "cursor pagination", type: :controller do
+    include GraphitiSpecHelpers
+
+    controller(ApplicationController) do
+      def index
+        records = resource.all(params)
+        render jsonapi: records
+      end
+
+      def resource
+        Legacy::AuthorResource
+      end
+    end
+
+    before do
+      allow(controller.request.env).to receive(:[])
+        .with(anything).and_call_original
+      allow(controller.request.env).to receive(:[])
+        .with("PATH_INFO") { path }
+    end
+
+    let(:path) { "/legacy/authors" }
+
+    let!(:author1) { Legacy::Author.create!(age: 10, last_login: 4.day.ago) }
+    let!(:author2) { Legacy::Author.create!(age: 20, last_login: 2.days.ago) }
+    let!(:author3) { Legacy::Author.create!(age: 20, last_login: 3.days.ago) }
+    let!(:author4) { Legacy::Author.create!(age: 30, last_login: 1.days.ago) }
+
+    around do |e|
+      original = Legacy::AuthorResource.cursor_paginatable
+      Legacy::AuthorResource.cursor_paginatable = true
+      begin
+        e.run
+      ensure
+        Legacy::AuthorResource.cursor_paginatable = original
+      end
+    end
+
+    def decode(cursor)
+      JSON.parse(Base64.decode64(cursor)).deep_symbolize_keys
+    end
+
+    # don't go through 'd' helper b/c it is memoized
+    def ids
+      json["data"].map { |d| d["id"].to_i }
+    end
+
+    it "renders a cursor in meta" do
+      do_index({})
+      decoded = decode(json["data"][0]["meta"]["cursor"])
+      expect(decoded).to eq(offset: 1)
+      decoded = decode(json["data"][1]["meta"]["cursor"])
+      expect(decoded).to eq(offset: 2)
+    end
+
+    describe "using a rendered cursor" do
+      context "when paginating after" do
+        context "basic" do
+          it "works" do
+            do_index({})
+            cursor = json["data"][1]["meta"]["cursor"]
+            do_index(page: {after: cursor})
+            expect(ids).to eq([author3.id, author4.id])
+          end
+
+          it "respects page size" do
+            do_index({})
+            cursor = json["data"][1]["meta"]["cursor"]
+            do_index(page: {after: cursor, size: 1})
+            expect(ids).to eq([author3.id])
+          end
+        end
+
+        context "when given sort param" do
+          it "works asc" do
+            do_index(sort: "last_login")
+            expect(ids).to eq([author1.id, author3.id, author2.id, author4.id])
+            cursor = json["data"][0]["meta"]["cursor"]
+            do_index(sort: "last_login", page: {after: cursor})
+            expect(ids).to eq([author3.id, author2.id, author4.id])
+          end
+
+          it "works desc" do
+            do_index(sort: "-last_login")
+            expect(ids).to eq([4, 2, 3, 1])
+            cursor = json["data"][0]["meta"]["cursor"]
+            do_index(sort: "-last_login", page: {after: cursor})
+            expect(ids).to eq([author2.id, author3.id, author1.id])
+          end
+        end
+      end
+
+      context "when paging before" do
+        context "basic" do
+          # doesn't work bc offset not limit
+          xit "works" do
+            do_index({})
+            cursor = json["data"][3]["meta"]["cursor"]
+            do_index(page: {before: cursor})
+            expect(ids).to eq([author1.id, author2.id, author3.id])
+          end
+
+          it "respects page size" do
+            do_index({})
+            cursor = json["data"][3]["meta"]["cursor"]
+            do_index(page: {before: cursor, size: 2})
+            expect(ids).to eq([author2.id, author3.id])
+          end
+
+          context "when given sort param" do
+            it "works asc" do
+              do_index(sort: "last_login")
+              expect(ids).to eq([author1.id, author3.id, author2.id, author4.id])
+              cursor = json["data"][3]["meta"]["cursor"]
+              do_index(sort: "last_login", page: {before: cursor, size: 2})
+              expect(ids).to eq([author3.id, author2.id])
+            end
+  
+            it "works desc" do
+              do_index(sort: "-last_login")
+              expect(ids).to eq([author4.id, author2.id, author3.id, author1.id])
+              cursor = json["data"][3]["meta"]["cursor"]
+              do_index(sort: "-last_login", page: {before: cursor, size: 2})
+              expect(ids).to eq([author2.id, author3.id])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -66,11 +66,7 @@ RSpec.describe "pagination" do
     expect(ids).to eq([3, 4])
   end
 
-  context "when offset is given" do
-    before do
-      params[:page] = {offset: 2}
-    end
-
+  shared_examples "offset-based pagination" do
     it "works" do
       expect(ids).to eq([3, 4])
     end
@@ -108,6 +104,73 @@ RSpec.describe "pagination" do
       it "is yielded" do
         ids
         expect(@spy[:value]).to eq(2)
+      end
+    end
+  end
+
+  context "when offset is given" do
+    before do
+      params[:page] = {offset: 2}
+    end
+
+    include_examples "offset-based pagination"
+  end
+
+  context "when cursor is given" do
+    context "when offset-based" do
+      context "when 'after'" do
+        before do
+          params[:page] = {after: Base64.encode64({offset: 2}.to_json)}
+        end
+
+        include_examples "offset-based pagination"
+      end
+
+      context "when 'before'" do
+        before do
+          params[:page] = {before: Base64.encode64({offset: 4}.to_json), size: 3}
+        end
+
+        it "works" do
+          expect(ids).to eq([1, 2, 3])
+        end
+
+        context "alongside page size" do
+          before do
+            params[:page][:size] = 2
+          end
+
+          it "works" do
+            expect(ids).to eq([2, 3])
+          end
+        end
+
+        context "alongside page number" do
+          before do
+            params[:page][:number] = 2
+            params[:page][:size] = 1
+          end
+
+          it "raises helpful error" do
+            expect { ids }.to raise_error(Graphiti::Errors::UnsupportedBeforeCursor)
+          end
+        end
+
+        context "when a custom pagination override" do
+          before do
+            @spy = spy = {}
+            resource.paginate do |scope, current_page, per_page, ctx, offset|
+              spy[:value] = offset
+              scope
+            end
+            params[:page][:size] = 1
+          end
+
+          it "is yielded" do
+            ids
+            expect(@spy[:value]).to eq(2)
+          end
+        end
       end
     end
   end

--- a/spec/sideloading_spec.rb
+++ b/spec/sideloading_spec.rb
@@ -677,15 +677,36 @@ RSpec.describe "sideloading" do
         allow_sideload :positions, class: Sideloading::PositionSideload
       end
       params[:include] = "positions"
-      params[:page] = {
-        size: 1,
-        positions: {size: 1}
-      }
+      params[:page] = {size: 1}
     end
 
     it "works" do
+      params[:page][:positions] = {size: 1}
       render
       expect(included("positions").map(&:id)).to match_array([2])
+    end
+
+    context "with offset" do
+      before do
+        params[:page][:positions] = {offset: 1}
+      end
+
+      it "works" do
+        render
+        expect(included("positions").map(&:id)).to match_array([1])
+      end
+    end
+
+    context "with cursor" do
+      before do
+        cursor = Base64.encode64({offset: 1}.to_json)
+        params[:page][:positions] = {after: cursor}
+      end
+
+      it "works" do
+        render
+        expect(included("positions").map(&:id)).to match_array([1])
+      end
     end
   end
 


### PR DESCRIPTION
We currently support a `page[offset]` parameter. This updates the codebase to accept `before` and `after` cursors, applying the relevant `offset` logic as appropriate.

When JSON:API we're render `meta: { cursor: <cursor> }` for each entity, and when flat JSON/GraphQL we'll render `_cursor: <cursor>`. This is to support GQL queries like

```graphql
employees {
  nodes {
    firstName
    _cursor
  }
}
```

We're not doing a full `edges` implementation because A) I just kinda hate it and B) to value here is metadata about the relationship, mostly for M2M relationships, which Graphiti doesn't support yet anyway.

The cursor is Base64 encoded JSON of `{offset: <offset>}`.

In addition, we accept `?fields[page_info]=has_next_page,etc` to render the relevant `pageInfo` section. This uses the same code already used to populate pagination links and cursors.