### PR TITLE
Support schema for filters of extra attributes

### DIFF
--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -151,7 +151,8 @@ module Graphiti
             readable: true,
             writable: false,
             sortable: false,
-            filterable: false
+            filterable: false,
+            schema: true
           }
           options = defaults.merge(options)
           attribute_option(options, :readable)

--- a/lib/graphiti/schema.rb
+++ b/lib/graphiti/schema.rb
@@ -153,6 +153,8 @@ module Graphiti
     def extra_attributes(resource)
       {}.tap do |attrs|
         resource.extra_attributes.each_pair do |name, config|
+          next unless config[:schema]
+
           attrs[name] = {
             type: config[:type].to_s,
             readable: flag(config[:readable]),
@@ -181,11 +183,11 @@ module Graphiti
     def sorts(resource)
       {}.tap do |s|
         resource.sorts.each_pair do |name, sort|
-          next unless resource.attributes[name][:schema]
+          attr = resource.all_attributes[name]
+          next unless attr[:schema]
 
           config = {}
           config[:only] = sort[:only] if sort[:only]
-          attr = resource.attributes[name]
           if attr[:sortable].is_a?(Symbol)
             config[:guard] = true
           end
@@ -209,7 +211,7 @@ module Graphiti
           config[:deny] = filter[:deny].map(&:to_s) if filter[:deny]
           config[:dependencies] = filter[:dependencies].map(&:to_s) if filter[:dependencies]
 
-          attr = resource.attributes[name]
+          attr = resource.all_attributes[name]
           if attr[:filterable].is_a?(Symbol)
             if attr[:filterable] == :required
               config[:required] = true

--- a/lib/graphiti/version.rb
+++ b/lib/graphiti/version.rb
@@ -1,3 +1,3 @@
 module Graphiti
-  VERSION = "1.3.4"
+  VERSION = "1.3.5"
 end

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -577,6 +577,44 @@ RSpec.describe Graphiti::Schema do
       end
     end
 
+    context "when extra attribute has schema false" do
+      before do
+        employee_resource.class_eval do
+          extra_attribute :net_sales, :float, schema: false
+        end
+      end
+
+      it "is not in the list of extra_attributes" do
+        expect(schema[:resources][0][:extra_attributes]).not_to have_key(:net_sales)
+      end
+    end
+
+    context "when extra attribute is also a filter" do
+      before do
+        employee_resource.class_eval do
+          extra_attribute :net_sales, :float, filterable: true
+          filter :net_sales, only: [:eq]
+        end
+      end
+
+      it "is in the list of filters" do
+        expect(schema[:resources][0][:filters]).to have_key(:net_sales)
+      end
+    end
+
+    context "when extra attribute is also a sort" do
+      before do
+        employee_resource.class_eval do
+          extra_attribute :net_sales, :float, sortable: true
+          sort :net_sales
+        end
+      end
+
+      it "is in the list of sorts" do
+        expect(schema[:resources][0][:sorts]).to have_key(:net_sales)
+      end
+    end
+
     context "when an additional statistic/calculations" do
       before do
         employee_resource.stat age: [:average, :sum]


### PR DESCRIPTION
Defining a filter for an extra attribute causes the schema generation to
fail since it doesn't consider extra attributes.

This change allows filters (and sorts) of extra attributes to be
included in the generated schema. It also adds support for the `schema`
attribute option for extra attributes for parity with attributes.

Fixes https://github.com/graphiti-api/graphiti/issues/378

What do you think? For parity with attributes it makes sense to me,
the functionality is already there, this is makes schema generation work.