### PR TITLE
Decouple attribute and filter schema flag

### DIFF
--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -23,6 +23,8 @@ module Graphiti
             end
 
             required = att[:filterable] == :required || !!opts[:required]
+            schema = !!opts[:via_attribute_dsl] ? att[:schema] : opts[:schema] != false
+
             config[:filters][name.to_sym] = {
               aliases: aliases,
               name: name.to_sym,
@@ -32,6 +34,7 @@ module Graphiti
               single: !!opts[:single],
               dependencies: opts[:dependent],
               required: required,
+              schema: schema,
               operators: operators.to_hash,
               allow_nil: opts.fetch(:allow_nil, filters_accept_nil_by_default),
               deny_empty: opts.fetch(:deny_empty, filters_deny_empty_by_default)
@@ -130,7 +133,7 @@ module Graphiti
           options[:sortable] ? sort(name) : config[:sorts].delete(name)
 
           if options[:filterable]
-            filter(name, allow: options[:allow])
+            filter(name, allow: options[:allow], via_attribute_dsl: true)
           else
             config[:filters].delete(name)
           end

--- a/lib/graphiti/schema.rb
+++ b/lib/graphiti/schema.rb
@@ -197,7 +197,7 @@ module Graphiti
     def filters(resource)
       {}.tap do |f|
         resource.filters.each_pair do |name, filter|
-          next unless resource.attributes[name][:schema]
+          next unless resource.filters[name][:schema]
 
           config = {
             type: filter[:type].to_s,

--- a/lib/graphiti/version.rb
+++ b/lib/graphiti/version.rb
@@ -1,3 +1,3 @@
 module Graphiti
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -529,6 +529,28 @@ RSpec.describe Graphiti::Schema do
       end
     end
 
+    context "when the attribute is schema: false then .filter called" do
+      before do
+        employee_resource.filter :hidden_attribute
+      end
+
+      it "appears in the schema" do
+        expect(schema[:resources][0][:filters].key?(:hidden_attribute))
+          .to eq(true)
+      end
+
+      context "when passed schema: false at filter level" do
+        before do
+          employee_resource.filter :hidden_attribute, schema: false
+        end
+
+        it "does not appear in the schema" do
+          expect(schema[:resources][0][:filters].key?(:hidden_attribute))
+            .to eq(false)
+        end
+      end
+    end
+
     context "when attribute changes to schema true" do
       before do
         employee_resource.class_eval do


### PR DESCRIPTION
Previously if you passed `attribute ..., schema: false`, any corresponding filter would also not appear in the schema. Now, if you explicitly call `.filter`, just the filter will appear in the schema. You can avoid this by passing `schema: false`.