### PR TITLE
Make attribute filterable when .filter called

### DIFF
--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -9,7 +9,11 @@ module Graphiti
           opts = args.extract_options!
           type_override = args[0]
 
-          if (att = get_attr(name, :filterable, raise_error: :only_unsupported))
+          if (att = (attributes[name] || extra_attributes[name]))
+            # We're opting in to filtering, so force this
+            # UNLESS the filter is guarded at the attribute level
+            att[:filterable] = true if att[:filterable] == false
+
             aliases = [name, opts[:aliases]].flatten.compact
             operators = FilterOperators.build(self, att[:type], opts, &blk)
 

--- a/lib/graphiti/version.rb
+++ b/lib/graphiti/version.rb
@@ -1,3 +1,3 @@
 module Graphiti
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -1338,11 +1338,12 @@ RSpec.describe "filtering" do
           resource.attributes[:foo][:filterable] = false
         end
 
-        it "raises helpful error" do
+        it "makes it filterable" do
           expect {
             resource.filter :foo do
             end
-          }.to raise_error(Graphiti::Errors::AttributeError, "PORO::EmployeeResource: Tried to add filter attribute :foo, but the attribute was marked :filterable => false.")
+          }.to change { resource.attributes[:foo][:filterable] }
+            .from(false).to(true)
         end
       end
     end


### PR DESCRIPTION
Previously if you did

```ruby
attribute :foo, :string, filterable: false
filter :foo do
  # ...
end
```

It would raise an error that you're trying to make something explicitly marked unfilterable filterable.

Instead, let's just update the attribute to be filterable. Not only does this make logical sense, it allows us to do library dev things (like generate an unfilterable attribute under-the-hood while allowing user overrides).