### PR TITLE
Handle malformed parameters with a 400 instead of a 500

### DIFF
--- a/lib/graphiti/resource/links.rb
+++ b/lib/graphiti/resource/links.rb
@@ -72,14 +72,18 @@ module Graphiti
         request_path = request_path.split(".")[0]
 
         endpoints.any? do |e|
-          has_id = params[:id] || params[:data].try(:[], :id)
-          path = request_path
-          if [:update, :show, :destroy].include?(context_namespace) && has_id
-            path = request_path.split("/")
-            path.pop
-            path = path.join("/")
+          begin
+            has_id = params[:id] || params[:data].try(:[], :id)
+            path = request_path
+            if [:update, :show, :destroy].include?(context_namespace) && has_id
+              path = request_path.split("/")
+              path.pop
+              path = path.join("/")
+            end
+            e[:full_path].to_s == path && e[:actions].include?(context_namespace)
+          rescue
+            false
           end
-          e[:full_path].to_s == path && e[:actions].include?(context_namespace)
         end
       end
 


### PR DESCRIPTION
When processing an invalid request that is missing the following
headers:
```
'Content-Type': 'application/json'
```
and has the following body:

```
{'data': 'relationships'}
```

results in:

```
TypeError (no implicit conversion of Symbol into Integer):

activesupport (6.1.4.1) lib/active_support/core_ext/object/try.rb:15:in `[]'
activesupport (6.1.4.1) lib/active_support/core_ext/object/try.rb:15:in `public_send'
activesupport (6.1.4.1) lib/active_support/core_ext/object/try.rb:15:in `try'
graphiti (1.3.3) lib/graphiti/resource/links.rb:75:in `block in
allow_request?'
```
Which responds with a 500 status.

Instead the behavior should respond with a 400.