### PR TITLE
Fix Sparse fieldsets to work with relationships

### DIFF
--- a/lib/graphiti/serializer.rb
+++ b/lib/graphiti/serializer.rb
@@ -40,7 +40,7 @@ module Graphiti
         # conditional without affecting the relationship.
         def requested_relationships(fields)
           @_relationships.select do |k, _|
-            _conditionally_included?(self.class.relationship_condition_blocks, k)
+            _conditionally_included?(self.class.relationship_condition_blocks, k) && (fields.nil? || fields.include?(k))
           end
         end
       end


### PR DESCRIPTION
Fixes #301

The sparse fieldsets is not filtering relationships. Currently if we specify any attribute and/or relationship in `fields` param, it works correctly on attributes but the not on relationships. It returns all the relationships, ignoring `fields` param. According to [jsonapi format](https://jsonapi.org/format/#fetching-sparse-fieldsets) both attribute and relationship should be supported. This PR fixes that.

In case of `fields` param having only attribute(s) in them, this change will restrict all relationships as well because of the following line from jsonapi format doc (fields represent both attributes and relationships)

> If a client requests a restricted set of fields for a given resource type, an endpoint MUST NOT include additional fields in resource objects of that type in its response.

I have not changed `include` section because of the following specification from the jsonapi format doc.
> The only exception to the full linkage requirement is when relationship fields that would otherwise contain linkage data are excluded via sparse fieldsets

So in case of having a relationship mentioned in `include` and sparse fieldsets having some atttribute, this will still return the relationship but the linkage won't be there.