### PR TITLE
Fix RTE in ActiveRecord adapter when using null string filter

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -40,7 +40,7 @@ module Graphiti
 
       def filter_string_eq(scope, attribute, value, is_not: false)
         column = column_for(scope, attribute)
-        clause = column.lower.eq_any(value.map(&:downcase))
+        clause = column.lower.eq_any(value.map { |val| val&.downcase })
         is_not ? scope.where.not(clause) : scope.where(clause)
       end
 

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -327,6 +327,7 @@ module Legacy
 
   class AuthorResource < ApplicationResource
     attribute :first_name, :string
+    attribute :last_name, :string
     attribute :fname, :string # alias
     attribute :age, :integer
     attribute :birthdays, :integer # alias

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -1019,6 +1019,7 @@ if ENV["APPRAISAL_INITIALIZED"]
         expect(json["data"]["attributes"].except("identifier")).to eq({
           "first_name" => "Stephen",
           "fname" => "Stephen", # alias
+          "last_name" => "King",
           "age" => 70,
           "birthdays" => 70, # alias
           "float_age" => 70.03,

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -24,6 +24,7 @@ if ENV["APPRAISAL_INITIALIZED"]
 
     let!(:author1) do
       Legacy::Author.create! first_name: "Stephen",
+        last_name: "King",
         age: 70,
         active: true,
         float_age: 70.03,
@@ -38,6 +39,7 @@ if ENV["APPRAISAL_INITIALIZED"]
     end
     let!(:author2) do
       Legacy::Author.create! first_name: "George",
+        last_name: "Martin",
         age: 65,
         active: false,
         float_age: 70.01,
@@ -281,6 +283,15 @@ if ENV["APPRAISAL_INITIALIZED"]
           it "executes case-insensitive search" do
             expect(ids).to eq([author2.id, author3.id])
           end
+
+          context "when value is nil" do
+            let(:filter) { {last_name: value} }
+            let(:value) { {eq: "null"} }
+
+            it "works" do
+              expect(ids).to eq([author3.id])
+            end
+          end
         end
 
         context "nothing" do
@@ -305,6 +316,15 @@ if ENV["APPRAISAL_INITIALIZED"]
           it "executes case-insensitive NOT search" do
             expect(ids).to eq([author1.id])
           end
+
+          context "when value is nil" do
+            let(:filter) { {last_name: value} }
+            let(:value) { {'!eq': "null"} }
+
+            it "works" do
+              expect(ids).to eq([author1.id, author2.id])
+            end
+          end
         end
 
         # test not_ alternative to !
@@ -313,6 +333,15 @@ if ENV["APPRAISAL_INITIALIZED"]
 
           it "executes case-insensitive NOT search" do
             expect(ids).to eq([author1.id])
+          end
+
+          context "when value is nil" do
+            let(:filter) { {last_name: value} }
+            let(:value) { {not_eq: "null"} }
+
+            it "works" do
+              expect(ids).to eq([author1.id, author2.id])
+            end
           end
         end
 


### PR DESCRIPTION
If one's resource is backed by ActiveRecord, an RTE is thrown if one allows nil and tries to filter by null on a string value. The adapter maps the filter values with `downcase` without checking for nil.

@richmolj 