### PR TITLE
Fix test failures re: uninitialized constant Position

### DIFF
--- a/lib/graphiti/resource/sideloading.rb
+++ b/lib/graphiti/resource/sideloading.rb
@@ -68,7 +68,7 @@ module Graphiti
           model_ref = model
           has_many name, opts do
             params do |hash|
-              hash[:filter][:"#{as}_type"] = { eql: model_ref.name }
+              hash[:filter][:"#{as}_type"] = {eql: model_ref.name}
             end
 
             instance_eval(&blk) if blk
@@ -82,7 +82,7 @@ module Graphiti
           model_ref = model
           has_one name, opts do
             params do |hash|
-              hash[:filter][:"#{as}_type"] = { eql: model_ref.name }
+              hash[:filter][:"#{as}_type"] = {eql: model_ref.name}
             end
 
             instance_eval(&blk) if blk

--- a/spec/integration/rails/stats_spec.rb
+++ b/spec/integration/rails/stats_spec.rb
@@ -13,7 +13,7 @@ if ENV["APPRAISAL_INITIALIZED"]
 
     context "basic" do
       it "works" do
-        proxy = PositionResource.all(stats: { total: "count" })
+        proxy = PositionResource.all(stats: {total: "count"})
         expect(proxy.stats).to eq({
           total: {
             count: 6
@@ -24,7 +24,7 @@ if ENV["APPRAISAL_INITIALIZED"]
 
     context "when grouping" do
       it "works" do
-        proxy = PositionResource.all(stats: { total: "count", group_by: :employee_id })
+        proxy = PositionResource.all(stats: {total: "count", group_by: :employee_id})
         expect(proxy.stats).to eq({
           total: {
             count: {

--- a/spec/integration/rails/stats_spec.rb
+++ b/spec/integration/rails/stats_spec.rb
@@ -1,38 +1,40 @@
-RSpec.describe "stats" do
-  let!(:pos1) { Position.create!(title: "a", employee_id: 1) }
-  let!(:pos2) { Position.create!(title: "b", employee_id: 2) }
-  let!(:pos3) { Position.create!(title: "c", employee_id: 2) }
-  let!(:pos4) { Position.create!(title: "d", employee_id: 2) }
-  let!(:pos5) { Position.create!(title: "e", employee_id: 3) }
-  let!(:pos6) { Position.create!(title: "f", employee_id: 3) }
+if ENV["APPRAISAL_INITIALIZED"]
+  RSpec.describe "stats" do
+    let!(:pos1) { Position.create!(title: "a", employee_id: 1) }
+    let!(:pos2) { Position.create!(title: "b", employee_id: 2) }
+    let!(:pos3) { Position.create!(title: "c", employee_id: 2) }
+    let!(:pos4) { Position.create!(title: "d", employee_id: 2) }
+    let!(:pos5) { Position.create!(title: "e", employee_id: 3) }
+    let!(:pos6) { Position.create!(title: "f", employee_id: 3) }
 
-  after do
-    Position.delete_all
-  end
-
-  context "basic" do
-    it "works" do
-      proxy = PositionResource.all(stats: { total: "count" })
-      expect(proxy.stats).to eq({
-        total: {
-          count: 6
-        }
-      })
+    after do
+      Position.delete_all
     end
-  end
 
-  context "when grouping" do
-    it "works" do
-      proxy = PositionResource.all(stats: { total: "count", group_by: :employee_id })
-      expect(proxy.stats).to eq({
-        total: {
-          count: {
-            1 => 1,
-            2 => 3,
-            3 => 2
+    context "basic" do
+      it "works" do
+        proxy = PositionResource.all(stats: { total: "count" })
+        expect(proxy.stats).to eq({
+          total: {
+            count: 6
           }
-        }
-      })
+        })
+      end
+    end
+
+    context "when grouping" do
+      it "works" do
+        proxy = PositionResource.all(stats: { total: "count", group_by: :employee_id })
+        expect(proxy.stats).to eq({
+          total: {
+            count: {
+              1 => 1,
+              2 => 3,
+              3 => 2
+            }
+          }
+        })
+      end
     end
   end
 end

--- a/spec/rendering_spec.rb
+++ b/spec/rendering_spec.rb
@@ -587,7 +587,7 @@ RSpec.describe "serialization" do
         end
       end
 
-      context 'when a multi-word stat' do
+      context "when a multi-word stat" do
         before do
           resource.stat multi_word: [:average] do
             average do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ Graphiti.setup!
 
 # Optional dep for cross-api requests
 require "faraday"
+require "base64"
 
 RSpec.configure do |config|
   config.include GraphitiSpecHelpers::RSpec


### PR DESCRIPTION
`Position` is undefined because it's not wrapped in the appraisal check, because when the tests run without appraisal ActiveRecord isn't loaded.