### PR TITLE
Prefer #update over #update_attributes

### DIFF
--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -153,10 +153,12 @@ module Graphiti
       success
     end
 
-    def update_attributes
+    def update
       data
       save(action: :update)
     end
+
+    alias update_attributes update
 
     def include_hash
       @include_hash ||= begin


### PR DESCRIPTION
Using/allowing `@resource.update` instead of `@resource.update_attributes` might help out a lot of rubocop + graphiti users, as Rubocop loves to think that `@resource.update_attributes` is out-of-date Rails code and will automatically change it to `@resource.update` which before this update broke things. 

This keeps graphiti a little more in sync with the standard Railsy controller pattern