### PR TITLE
Add support for caching renders in Graphiti, and better support using etags and `stale?` in the controller

### DIFF
--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -185,6 +185,7 @@ require "graphiti/extensions/temp_id"
 require "graphiti/serializer"
 require "graphiti/query"
 require "graphiti/debugger"
+require "graphiti/util/cache_debug"
 
 if defined?(ActiveRecord)
   require "graphiti/adapters/active_record"

--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -107,10 +107,12 @@ module Graphiti
     end
   end
 
-  def self.cache(name, kwargs = {}, &block)
-    ::Rails.cache.fetch(name, **kwargs) do
-      block.call
-    end
+  def self.cache=(val)
+    @cache = val
+  end
+
+  def self.cache
+    @cache
   end
 end
 

--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -106,6 +106,12 @@ module Graphiti
       r.apply_sideloads_to_serializer
     end
   end
+
+  def self.cache(name, kwargs = {}, &block)
+    ::Rails.cache.fetch(name, **kwargs) do
+      block.call
+    end
+  end
 end
 
 require "graphiti/version"

--- a/lib/graphiti/configuration.rb
+++ b/lib/graphiti/configuration.rb
@@ -20,6 +20,7 @@ module Graphiti
     attr_reader :debug, :debug_models
 
     attr_writer :schema_path
+    attr_writer :cache_rendering
 
     # Set defaults
     # @api private
@@ -61,10 +62,6 @@ module Graphiti
           raise "You must configure a cache store in order to use cache_rendering. Set Graphiti.cache = Rails.cache, for example."
         end
       end
-    end
-
-    def cache_rendering=(val)
-      @cache_rendering = val
     end
 
     def schema_path

--- a/lib/graphiti/configuration.rb
+++ b/lib/graphiti/configuration.rb
@@ -32,6 +32,7 @@ module Graphiti
       @pagination_links = false
       @typecast_reads = true
       @raise_on_missing_sidepost = true
+      @cache_rendering = false
       self.debug = ENV.fetch("GRAPHITI_DEBUG", true)
       self.debug_models = ENV.fetch("GRAPHITI_DEBUG_MODELS", false)
 
@@ -50,6 +51,20 @@ module Graphiti
           Graphiti.logger = logger
         end
       end
+    end
+
+    def cache_rendering?
+      use_caching = @cache_rendering && Graphiti.cache.respond_to?(:fetch)
+
+      use_caching.tap do |use|
+        if @cache_rendering && !Graphiti.cache&.respond_to?(:fetch)
+          raise "You must configure a cache store in order to use cache_rendering. Set Graphiti.cache = Rails.cache, for example."
+        end
+      end
+    end
+
+    def cache_rendering=(val)
+      @cache_rendering = val
     end
 
     def schema_path

--- a/lib/graphiti/debugger.rb
+++ b/lib/graphiti/debugger.rb
@@ -98,7 +98,11 @@ module Graphiti
           took = ((stop - start) * 1000.0).round(2)
           logs << [""]
           logs << ["=== Graphiti Debug", :green, true]
-          logs << ["Rendering:", :green, true]
+          logs << if payload[:proxy]&.cached?
+            ["Rendering (cached):", :green, true]
+          else
+            ["Rendering:", :green, true]
+          end
           logs << ["Took: #{took}ms", :magenta, true]
         end
       end

--- a/lib/graphiti/debugger.rb
+++ b/lib/graphiti/debugger.rb
@@ -98,10 +98,29 @@ module Graphiti
           took = ((stop - start) * 1000.0).round(2)
           logs << [""]
           logs << ["=== Graphiti Debug", :green, true]
-          logs << if payload[:proxy]&.cached? && Graphiti.config.cache_rendering?
-            ["Rendering (cached):", :green, true]
+          if payload[:proxy]&.cached? && Graphiti.config.cache_rendering?
+            logs << ["Rendering (cached):", :green, true]
+
+            Graphiti::Util::CacheDebug.new(payload[:proxy]).analyze do |cache_debug|
+              logs << ["Cache key for #{cache_debug.name}", :blue, true]
+              if cache_debug.volatile?
+                logs << [" \\_ volatile | Request count: #{cache_debug.request_count} | Hit count: #{cache_debug.hit_count}", :red, true]
+              else
+                logs << [" \\_   stable | Request count: #{cache_debug.request_count} | Hit count: #{cache_debug.hit_count}", :blue, true]
+              end
+
+              if cache_debug.changed_key?
+                logs << [" [x] cache key changed #{cache_debug.last_version[:etag]} -> #{cache_debug.current_version[:etag]}", :red]
+                logs << ["      removed: #{cache_debug.removed_segments}", :red]
+                logs << ["        added: #{cache_debug.added_segments}", :red]
+              elsif cache_debug.new_key?
+                logs << [" [+] cache key added #{cache_debug.current_version[:etag]}", :red, true]
+              else
+                logs << [" [✓] #{cache_debug.current_version[:etag]}", :green, true]
+              end
+            end
           else
-            ["Rendering:", :green, true]
+            logs << ["Rendering:", :green, true]
           end
           logs << ["Took: #{took}ms", :magenta, true]
         end

--- a/lib/graphiti/debugger.rb
+++ b/lib/graphiti/debugger.rb
@@ -98,7 +98,7 @@ module Graphiti
           took = ((stop - start) * 1000.0).round(2)
           logs << [""]
           logs << ["=== Graphiti Debug", :green, true]
-          logs << if payload[:proxy]&.cached?
+          logs << if payload[:proxy]&.cached? && Graphiti.config.cache_rendering?
             ["Rendering (cached):", :green, true]
           else
             ["Rendering:", :green, true]

--- a/lib/graphiti/debugger.rb
+++ b/lib/graphiti/debugger.rb
@@ -103,10 +103,10 @@ module Graphiti
 
             Graphiti::Util::CacheDebug.new(payload[:proxy]).analyze do |cache_debug|
               logs << ["Cache key for #{cache_debug.name}", :blue, true]
-              if cache_debug.volatile?
-                logs << [" \\_ volatile | Request count: #{cache_debug.request_count} | Hit count: #{cache_debug.hit_count}", :red, true]
+              logs << if cache_debug.volatile?
+                [" \\_ volatile | Request count: #{cache_debug.request_count} | Hit count: #{cache_debug.hit_count}", :red, true]
               else
-                logs << [" \\_   stable | Request count: #{cache_debug.request_count} | Hit count: #{cache_debug.hit_count}", :blue, true]
+                [" \\_   stable | Request count: #{cache_debug.request_count} | Hit count: #{cache_debug.hit_count}", :blue, true]
               end
 
               if cache_debug.changed_key?

--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -1,3 +1,5 @@
+require "digest"
+
 module Graphiti
   class Query
     attr_reader :resource, :association_name, :params, :action
@@ -232,7 +234,21 @@ module Graphiti
       ![false, "false"].include?(@params[:paginate])
     end
 
+    def cache_key
+      "args-#{query_cache_key}"
+    end
+
     private
+
+    def query_cache_key
+      attrs = {extra_fields: extra_fields,
+               fields: fields,
+               links: links?,
+               pagination_links: pagination_links?,
+               format: params[:format]}
+
+      Digest::SHA1.hexdigest(attrs.to_s)
+    end
 
     def cast_page_param(name, value)
       if [:before, :after].include?(name)

--- a/lib/graphiti/renderer.rb
+++ b/lib/graphiti/renderer.rb
@@ -68,7 +68,14 @@ module Graphiti
         options[:meta][:debug] = Debugger.to_a if debug_json?
         options[:proxy] = proxy
 
-        renderer.render(records, options)
+        if proxy.cache?
+          Graphiti.cache("#{proxy.cache_key}/render", version: proxy.updated_at, expires_in: proxy.cache_expires_in) do
+            options.delete(:cache) # ensure that we don't use JSONAPI-Resources's built-in caching logic
+            renderer.render(records, options)
+          end
+        else
+          renderer.render(records, options)
+        end
       end
     end
 

--- a/lib/graphiti/renderer.rb
+++ b/lib/graphiti/renderer.rb
@@ -68,8 +68,8 @@ module Graphiti
         options[:meta][:debug] = Debugger.to_a if debug_json?
         options[:proxy] = proxy
 
-        if proxy.cache?
-          Graphiti.cache("#{proxy.cache_key}/render", version: proxy.updated_at, expires_in: proxy.cache_expires_in) do
+        if proxy.cache? && Graphiti.config.cache_rendering?
+          Graphiti.cache.fetch("graphiti:render/#{proxy.cache_key}", version: proxy.updated_at, expires_in: proxy.cache_expires_in) do
             options.delete(:cache) # ensure that we don't use JSONAPI-Resources's built-in caching logic
             renderer.render(records, options)
           end

--- a/lib/graphiti/resource/interface.rb
+++ b/lib/graphiti/resource/interface.rb
@@ -4,6 +4,11 @@ module Graphiti
       extend ActiveSupport::Concern
 
       class_methods do
+        def cache_resource(expires_in: false)
+          @cache_resource = true
+          @cache_expires_in = expires_in
+        end
+
         def all(params = {}, base_scope = nil)
           validate_request!(params)
           _all(params, {}, base_scope)
@@ -13,7 +18,7 @@ module Graphiti
         def _all(params, opts, base_scope)
           runner = Runner.new(self, params, opts.delete(:query), :all)
           opts[:params] = params
-          runner.proxy(base_scope, opts)
+          runner.proxy(base_scope, opts.merge(caching_options))
         end
 
         def find(params = {}, base_scope = nil)
@@ -31,10 +36,14 @@ module Graphiti
           params[:filter][:id] = id if id
 
           runner = Runner.new(self, params, nil, :find)
-          runner.proxy base_scope,
+
+          find_options = {
             single: true,
             raise_on_missing: true,
             bypass_required_filters: true
+          }.merge(caching_options)
+
+          runner.proxy base_scope, find_options
         end
 
         def build(params, base_scope = nil)
@@ -44,6 +53,10 @@ module Graphiti
         end
 
         private
+
+        def caching_options
+          {cache: @cache_resource, cache_expires_in: @cache_expires_in}
+        end
 
         def validate_request!(params)
           return if Graphiti.context[:graphql] || !validate_endpoints?

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -2,19 +2,30 @@ module Graphiti
   class ResourceProxy
     include Enumerable
 
-    attr_reader :resource, :query, :scope, :payload
+    attr_reader :resource, :query, :scope, :payload, :cache_expires_in, :cache
 
     def initialize(resource, scope, query,
       payload: nil,
       single: false,
-      raise_on_missing: false)
+      raise_on_missing: false,
+      cache: nil,
+      cache_expires_in: nil)
+
       @resource = resource
       @scope = scope
       @query = query
       @payload = payload
       @single = single
       @raise_on_missing = raise_on_missing
+      @cache = cache
+      @cache_expires_in = cache_expires_in
     end
+
+    def cache?
+      !!@cache
+    end
+
+    alias_method :cached?, :cache?
 
     def single?
       !!@single
@@ -178,6 +189,22 @@ module Graphiti
 
     def debug_requested?
       query.debug_requested?
+    end
+
+    def updated_at
+      @scope.updated_at
+    end
+
+    def etag
+      "W/#{ActiveSupport::Digest.hexdigest(cache_key_with_version.to_s)}"
+    end
+
+    def cache_key
+      ActiveSupport::Cache.expand_cache_key([@scope.cache_key, @query.cache_key])
+    end
+
+    def cache_key_with_version
+      ActiveSupport::Cache.expand_cache_key([@scope.cache_key_with_version, @query.cache_key])
     end
 
     private

--- a/lib/graphiti/runner.rb
+++ b/lib/graphiti/runner.rb
@@ -71,7 +71,9 @@ module Graphiti
         query,
         payload: deserialized_payload,
         single: opts[:single],
-        raise_on_missing: opts[:raise_on_missing]
+        raise_on_missing: opts[:raise_on_missing],
+        cache: opts[:cache],
+        cache_expires_in: opts[:cache_expires_in]
     end
   end
 end

--- a/lib/graphiti/serializer.rb
+++ b/lib/graphiti/serializer.rb
@@ -99,7 +99,7 @@ module Graphiti
 
     def strip_relationships?
       return false unless Graphiti.config.links_on_demand
-      params = Graphiti.context[:object].params || {}
+      params = Graphiti.context[:object]&.params || {}
       [false, nil, "false"].include?(params[:links])
     end
   end

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -209,13 +209,16 @@ module Graphiti
       end
     end
 
-    def load(parents, query, graph_parent)
-      params, opts, proxy = nil, nil, nil
+    def build_resource_proxy(parents, query, graph_parent)
+      params = nil
+      opts = nil
+      proxy = nil
 
       with_error_handling Errors::SideloadParamsError do
         params = load_params(parents, query)
         params_proc&.call(params, parents, context)
         return [] if blank_query?(params)
+
         opts = load_options(parents, query)
         opts[:sideload] = self
         opts[:parent] = graph_parent
@@ -228,7 +231,11 @@ module Graphiti
         pre_load_proc&.call(proxy, parents)
       end
 
-      proxy.to_a
+      proxy
+    end
+
+    def load(parents, query, graph_parent)
+      build_resource_proxy(parents, query, graph_parent).to_a
     end
 
     # Override in subclass

--- a/lib/graphiti/util/cache_debug.rb
+++ b/lib/graphiti/util/cache_debug.rb
@@ -20,7 +20,7 @@ module Graphiti
       end
 
       def current_version
-        @current_version ||= { 
+        @current_version ||= {
           cache_key: proxy.cache_key_with_version,
           version: proxy.updated_at,
           expires_in: proxy.cache_expires_in,
@@ -50,10 +50,7 @@ module Graphiti
 
       def change_percentage
         return 0 if request_count == 0
-
         (miss_count.to_i / request_count.to_f * 100).round(1)
-      rescue Exception => e
-        puts e.inspect
       end
 
       def volatile?

--- a/lib/graphiti/util/cache_debug.rb
+++ b/lib/graphiti/util/cache_debug.rb
@@ -1,0 +1,91 @@
+module Graphiti
+  module Util
+    class CacheDebug
+      attr_reader :proxy
+
+      def initialize(proxy)
+        @proxy = proxy
+      end
+
+      def last_version
+        @last_version ||= Graphiti.cache.read(key) || {}
+      end
+
+      def name
+        "#{Graphiti.context[:object].request.method} #{Graphiti.context[:object].request.url}"
+      end
+
+      def key
+        "graphiti:debug/#{name}"
+      end
+
+      def current_version
+        @current_version ||= { 
+          cache_key: proxy.cache_key_with_version,
+          version: proxy.updated_at,
+          expires_in: proxy.cache_expires_in,
+          etag: proxy.etag,
+          miss_count: last_version[:miss_count].to_i + (changed_key? ? 1 : 0),
+          hit_count: last_version[:hit_count].to_i + (!changed_key? && !new_key? ? 1 : 0),
+          request_count: last_version[:request_count].to_i + (last_version.present? ? 1 : 0)
+        }
+      end
+
+      def analyze
+        yield self
+        save
+      end
+
+      def request_count
+        current_version[:request_count]
+      end
+
+      def miss_count
+        current_version[:miss_count]
+      end
+
+      def hit_count
+        current_version[:hit_count]
+      end
+
+      def change_percentage
+        return 0 if request_count == 0
+
+        (miss_count.to_i / request_count.to_f * 100).round(1)
+      rescue Exception => e
+        puts e.inspect
+      end
+
+      def volatile?
+        change_percentage > 50
+      end
+
+      def new_key?
+        last_version[:cache_key].blank? && proxy.cache_key_with_version
+      end
+
+      def changed_key?
+        last_version[:cache_key] != proxy.cache_key_with_version && !new_key?
+      end
+
+      def removed_segments
+        changes[1] - changes[0]
+      end
+
+      def added_segments
+        changes[0] - changes[1]
+      end
+
+      def changes
+        sub_keys_old = last_version[:cache_key]&.scan(/\w+\/query-[a-z0-9-]+\/args-[a-z0-9-]+/).to_a || []
+        sub_keys_new = current_version[:cache_key]&.scan(/\w+\/query-[a-z0-9-]+\/args-[a-z0-9-]+/).to_a || []
+
+        [sub_keys_old, sub_keys_new]
+      end
+
+      def save
+        Graphiti.cache.write(key, current_version)
+      end
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -164,4 +164,27 @@ RSpec.describe Graphiti::Configuration do
       expect(Graphiti.config.raise_on_missing_sideload).to eq(false)
     end
   end
+
+  describe "#cache_rendering" do
+    it "defaults" do
+      expect(Graphiti.config.cache_rendering?).to eq(false)
+    end
+
+    it "is settable" do
+      Graphiti.configure do |c|
+        c.cache_rendering = true
+      end
+      Graphiti.cache = double(fetch: nil) # looks like a cache store
+      expect(Graphiti.config.cache_rendering?).to eq(true)
+    end
+
+    it "warns about not being configured correctly if cache_rendering is true without Graphiti.cache set up" do
+      Graphiti.cache = nil
+      Graphiti.configure do |c|
+        c.cache_rendering = true
+      end
+
+      expect { Graphiti.config.cache_rendering? }.to raise_error(/You must configure a cache store in order to use cache_rendering/)
+    end
+  end
 end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -1077,4 +1077,23 @@ RSpec.describe Graphiti::Query do
       end
     end
   end
+
+  describe "cache_key" do
+    it "generates a stable key" do
+      instance1 = described_class.new(resource, params)
+      instance2 = described_class.new(resource, params)
+
+      expect(instance1.cache_key).to be_present
+      expect(instance1.cache_key).to eq(instance2.cache_key)
+    end
+
+    it "generates a different key with different params" do
+      instance1 = described_class.new(resource, params)
+      instance2 = described_class.new(resource, {extra_fields: {positions: ["foo"]}})
+
+      expect(instance1.cache_key).to be_present
+      expect(instance2.cache_key).to be_present
+      expect(instance1.cache_key).not_to eq(instance2.cache_key)
+    end
+  end
 end

--- a/spec/resource_proxy_spec.rb
+++ b/spec/resource_proxy_spec.rb
@@ -8,4 +8,30 @@ RSpec.describe Graphiti::ResourceProxy do
       expect(subject).to be_kind_of(Graphiti::Delegates::Pagination)
     end
   end
+
+  describe "caching" do
+    let(:resource) { double }
+    let(:query) { double(cache_key: "query-hash") }
+    let(:scope) { double(cache_key: "scope-hash", cache_key_with_version: "scope-hash-123456") }
+
+    subject { described_class.new(resource, scope, query, **{}) }
+
+    it "cache_key combines query and scope cache keys" do
+      cache_key = subject.cache_key
+      expect(cache_key).to eq("scope-hash/query-hash")
+    end
+
+    it "generates stable etag" do
+      instance1 = described_class.new(resource, scope, query, **{})
+      instance2 = described_class.new(resource, scope, query, **{})
+
+      expect(instance1.etag).to be_present
+      expect(instance1.etag).to start_with("W/")
+
+      expect(instance2.etag).to be_present
+      expect(instance2.etag).to start_with("W/")
+
+      expect(instance1.etag).to eq(instance2.etag)
+    end
+  end
 end


### PR DESCRIPTION
This PR exposes some things that make supporting using rails built-in caching methods like `stale?` with Graphiti a snap, and also allowing the option of caching the render of a graphiti resource (which is often the most time-consuming part of the process)

Changes:
- expose `cache_key` method to resource instance
  this generates a combined stable cache key based on resource identifiers specified by the resource class, the specified sideloads, and any specified `extra_fields` or `fields`, `pages`, or `links` which will affect the response. 

- expose `cache_key_with_version` method to resource instance
   same as above, but with the last modified dates added in. If any included resource's `updated_at` changes, this key will change.

- expose `updated_at` method to resource instance
  returns the max `updated_at` date of the resource and any specified sideloads

- expose `etag` method to resource instance
  generate a Weak Etag based on the `cache_key_with_version` response. With `etag` and `updated_at` methods on a resource instance, using `stale?(@resource)` will respect them.

- for cached resources, rendering logic in Graphiti is wrapped in a cache block `Graphiti.cache.fetch("graphiti:render/#{@resource.cache_key}", version: @resource.updated_at, expires_in: @resource.expires_in ) { [expensive rendering] }`. 
 
  (Using `cache_key` and `version` together by default instead of using `cache_key_with_version` as the key better ensures we won’t flood a cache store with dead keys)

### Using Rails etags and `stale?`

You can now easily benefit from using rails etags without any additional logic by using the `stale?` method and passing in your resource. 

```ruby
class EmployeesController < ApplicationController
  def index
   @employees = Employees.all(params)
   respond_with @employees if stale?(@employees)
  end
end
```

### Cache the rendered json

You can also cache the json rendering-step of the resource, which in the case of json-api can sometimes be expensive. In order to cache a resource set up a cache store, enable `cache_rendering`, and then add a `cache_resource` directive to the resource you want to cache. For complex resources with many sideloads, this can improve your response time dramatically.

```ruby
Graphiti.configure do |c|
  c.cache_rendering = Rails.env.production?
  # c.debug = true
  # with debug enabled extra information about caching will be output
end

Graphiti.cache = ::Rails.cache # or whatever cache you want to use that conforms to the same typical cache interface with .read, .write. fetch, etc.
```

```ruby
class EmployeesController < ApplicationResource
  cache_resource, expires_in: 1.week 
end
```

### Debugging

With the debug flag enabled in Graphiti config extra information will be logged. This logic tries to make caching the render loop of graphiti dead simple, but sometimes a query with an argument that changes often (a relative time, like `Time.now` for example) will create an unstable cache key, negating any potential benefits. This problems are a little tricky to spot, but the debugging code below should help.

// stable key
```
=== Graphiti Debug
Rendering (cached):
Cache key for GET http://localhost:3000/api/v1/employees/2
 \_   stable | Request count: 7 | Hit count: 7
 [✓] W/73e604f858ad89740cdb24eed7ec641e
```

// volatile key
```
=== Graphiti Debug
Rendering (cached):
Cache key for GET http://localhost:3000/api/v1/employees?recent=true
 \_ volatile | Request count: 11 | Hit count: 1
 [x] cache key changed W/b7328a2889e4132d2b8145f33895043e -> W/d00e6de884f36cfa477fe3c363745300
      removed: ["employees/query-810d248a61b640c0da5211318de8780c-50-20240327220001166601/args-a6ca37e898a0e40863337849e839c41e2461058c"]
        added: ["employees/query-3349d42b4dfeed25467072ec237aa89f-50-20240327220001166601/args-a6ca37e898a0e40863337849e839c41e2461058c"]
```

The above illustrates that there have been 11 requests but only 1 of those was pulled from the cache, which in the above query's case is because the query was using `Time.now` as an argument.
