### PR TITLE
boolean_attribute sets type as :boolean

### DIFF
--- a/lib/graphiti/extensions/boolean_attribute.rb
+++ b/lib/graphiti/extensions/boolean_attribute.rb
@@ -21,7 +21,7 @@ module Graphiti
         def boolean_attribute(name, options = {}, &blk)
           blk ||= proc { @object.public_send(name) }
           field_name = :"is_#{name.to_s.delete("?")}"
-          attribute field_name, options, &blk
+          attribute field_name, :boolean, options, &blk
         end
       end
     end


### PR DESCRIPTION
I encountered this by reading the code, not encountering any particular issue.

Shouldn't `boolean_attribute` be setting the attribute type to `:boolean` automatically?