### PR TITLE
Fix compatibility issues with ActiveSupport::LogSubscriber#color

### DIFF
--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -83,7 +83,7 @@ module Graphiti
   end
 
   def self.log(msg, color = :white, bold = false)
-    colored = ActiveSupport::LogSubscriber.new.send(:color, msg, color, bold)
+    colored = ActiveSupport::LogSubscriber.new.send(:color, msg, color, bold: bold)
     logger.debug(colored)
   end
 

--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -83,7 +83,12 @@ module Graphiti
   end
 
   def self.log(msg, color = :white, bold = false)
-    colored = ActiveSupport::LogSubscriber.new.send(:color, msg, color, bold: bold)
+    if ::Rails::VERSION::MAJOR >= 7 && ::Rails::VERSION::MINOR >= 1
+      colored = ActiveSupport::LogSubscriber.new.send(:color, msg, color, bold: bold)
+    else
+      colored = ActiveSupport::LogSubscriber.new.send(:color, msg, color, bold)
+    end
+
     logger.debug(colored)
   end
 

--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -83,7 +83,7 @@ module Graphiti
   end
 
   def self.log(msg, color = :white, bold = false)
-    if ::Rails::VERSION::MAJOR >= 7 && ::Rails::VERSION::MINOR >= 1
+    if ::ActiveSupport.version >= Gem::Version.new("7.1")
       colored = ActiveSupport::LogSubscriber.new.send(:color, msg, color, bold: bold)
     else
       colored = ActiveSupport::LogSubscriber.new.send(:color, msg, color, bold)


### PR DESCRIPTION
Since release 7.1 Rails supports multiple styles for the `LogSubscriber` instead of just choosing whether to make text bold or not: https://github.com/rails/rails/commit/6016f9ef3190489d87c2249d6a150f5a4d1b0753#diff-5d89527388085e995e2b39777fb0a7e7f948727474d15e5aa8e3d887a328a6c3R172-R191

This PR aims to replace the old style syntax with a new one (based on an options hash instead of a legacy positional argument)