### PR TITLE
Show includes for sideloads in debugger

### DIFF
--- a/lib/graphiti/debugger.rb
+++ b/lib/graphiti/debugger.rb
@@ -140,7 +140,6 @@ module Graphiti
         params ||= {}
         params = params.to_unsafe_h if params.respond_to?(:to_unsafe_h)
         params.reject! { |k, v| [:controller, :action, :format, :debug].include?(k.to_sym) }
-        params.reject! { |k, v| k.to_sym == :include }
         params.deep_symbolize_keys
       end
 


### PR DESCRIPTION
Could the debugger show the `include` key in its output? It caused me some confusion as it wasn't showing up in the logs, but the data was being sideloaded with the include as I'd expect.

Before:

```
=== Graphiti Debug
Top Level Data Retrieval (+ sideloads):
VehicleResource.all({:filter=>{:id=>"car_123"}, :include=>"cheapest_used_cash_deal", :pagination_links=>true})
Took: 33.59ms
    \_ cheapest_used_cash_deal
       DealResource.all({:filter=>{:type=>"CASH"}, :sort=>"price"})
       Took: 1164.34ms
```

After:

```
=== Graphiti Debug
Top Level Data Retrieval (+ sideloads):
VehicleResource.all({:filter=>{:id=>"car_123"}, :include=>"cheapest_used_cash_deal", :pagination_links=>true})
Took: 44.45ms
    \_ cheapest_used_cash_deal
       DealResource.all({:filter=>{:type=>"CASH"}, :include=>"vehicle", :sort=>"price"})
       Took: 971.99ms
```