### PR TITLE
fix: check for url presence before trying to append to it

### DIFF
--- a/lib/graphiti/util/link.rb
+++ b/lib/graphiti/util/link.rb
@@ -48,6 +48,7 @@ module Graphiti
 
       def on_demand_links(url)
         return url unless Graphiti.config.links_on_demand
+        return unless url
 
         url << if url.include?("?")
           "&links=true"


### PR DESCRIPTION
A longstanding edge case bug I had fixed on my private develop branch