### PR TITLE
feat!: the model you inspect is the model that saves

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,67 @@
+# Upgrading Graphiti
+
+## 1.x to 2.0
+
+### Requirements
+
+Graphiti 2.0 requires Ruby 3.0+ and Rails 6.0+ (when using Rails).
+
+### The model you inspect is the model that saves
+
+Proxies returned by `build` and `find` now apply the request payload lazily, and expose the resulting model before anything is written:
+
+```ruby
+# Creates
+resource = MyResource.build(params)
+resource.data          # unsaved model, attributes applied
+resource.data.valid?   # inspect before committing to anything
+resource.save          # persists that same instance
+
+# Updates
+resource = MyResource.find(params)
+resource.assign_attributes(params)
+resource.data.changed  # dirty tracking works
+resource.update_attributes
+```
+
+`assign_attributes` is idempotent per payload, validation still runs before assignment, and the instance you inspect is the instance that saves.
+
+### Breaking: around_persistence receives the model, not the attributes hash
+
+To make the above hold, attributes are assigned to the model once, before the persistence hooks fire. `around_persistence` now wraps the save of an already-assigned model and receives that model:
+
+```ruby
+# 1.x
+def do_around_persistence(attributes)
+  attributes[:tenant_id] = current_tenant.id
+  model = yield
+  model.log_saved!
+end
+
+# 2.0
+def do_around_persistence(model)
+  model.tenant_id = current_tenant.id # last chance to touch the model before save, inside the transaction
+  saved = yield
+  saved.log_saved!
+end
+```
+
+To migrate, move attribute-hash modifications to `before_attributes` (which still receives the mutable hash, before assignment), or set the value on the model as above. Hooks that only wrap their yield - transactions, timing, post-save side effects - need no changes. Graphiti 1.x releases warn at runtime when a hook would be affected.
+
+`before/around/after_attributes` and `before/around/after_save` are unchanged.
+
+### Breaking: custom create/update overrides and pre-assigned models
+
+If a resource overrides `create` or `update` and callers inspect the model before saving, the override must accept the already-assigned model:
+
+```ruby
+def create(attributes, meta = nil, assigned_model: nil)
+```
+
+Without the keyword, saving a proxy whose model was inspected raises `Graphiti::Errors::AssignedModelNotSupported` rather than silently discarding changes made to the inspected instance. Overridden resources used only via plain `save` are unaffected.
+
+### Fine print
+
+- If you inspect the model before saving, the attributes callbacks run at inspection time (in your controller, outside the save transaction). On the plain `save` path they run inside the transaction, at the same point as 1.x.
+- Writable guards judge persisted state: a guard asking for the model gets a fresh build/find, never the current request's unsaved changes. A payload cannot influence its own authorization.
+- Sideposted child models are still built and assigned during save; `data` exposes the pre-assigned root model only.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,7 +21,11 @@ resource.save          # persists that same instance
 resource = MyResource.find(params)
 resource.assign_attributes(params)
 resource.data.changed  # dirty tracking works
-resource.update_attributes
+resource.update
+
+# or assign and save in one call, Rails-style
+resource = MyResource.find(params)
+resource.update(params)
 ```
 
 `assign_attributes` is idempotent per payload, validation still runs before assignment, and the instance you inspect is the instance that saves.

--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -84,6 +84,25 @@ module Graphiti
       end
     end
 
+    class AssignedModelNotSupported < Base
+      def initialize(resource_class, method_name)
+        @resource_class = resource_class
+        @method_name = method_name
+      end
+
+      def message
+        <<~MSG
+          #{@resource_class}: the model was already assigned via #assign_attributes (or #data before save), but ##{@method_name} is overridden without a parameter to receive it, so changes made to the unsaved model would be silently lost.
+
+          Accept and use the assigned model in your override:
+
+            def #{@method_name}(attributes, meta = nil, assigned_model: nil)
+
+          or persist with #save alone, without inspecting the model first. See UPGRADING.md.
+        MSG
+      end
+    end
+
     class RemoteWrite < Base
       def initialize(resource_class)
         @resource_class = resource_class

--- a/lib/graphiti/request_validators/validator.rb
+++ b/lib/graphiti/request_validators/validator.rb
@@ -17,7 +17,6 @@ module Graphiti
         return true unless @params.has_key?(:data)
 
         resource = @root_resource
-
         if @params[:data].has_key?(:type)
           if (meta_type = deserialized_payload.meta[:type].try(:to_sym))
             if @root_resource.type != meta_type && @root_resource.polymorphic?

--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -97,6 +97,12 @@ module Graphiti
       adapter.disassociate(parent, child, association_name, type)
     end
 
+    def assign_with_relationships(meta, attributes, relationships, caller_model = nil, foreign_key = nil)
+      persistence = Graphiti::Util::Persistence \
+        .new(self, meta, attributes, relationships, caller_model, foreign_key)
+      persistence.assign
+    end
+
     def persist_with_relationships(meta, attributes, relationships, caller_model = nil, foreign_key = nil)
       persistence = Graphiti::Util::Persistence \
         .new(self, meta, attributes, relationships, caller_model, foreign_key)

--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -123,15 +123,18 @@ module Graphiti
       adapter.disassociate(parent, child, association_name, type)
     end
 
-    def assign_with_relationships(meta, attributes, relationships, caller_model = nil, foreign_key = nil)
+    # TODO: make foreign_key a keyword once the satellite gems are rolled in - they call these positionally
+    def assign_with_relationships(meta, attributes, relationships, caller_model = nil, foreign_key = nil, model_instance: nil)
       persistence = Graphiti::Util::Persistence \
-        .new(self, meta, attributes, relationships, caller_model, foreign_key)
+        .new(self, meta, attributes, relationships, caller_model, foreign_key,
+          assigned_model: model_instance)
       persistence.assign
     end
 
-    def persist_with_relationships(meta, attributes, relationships, caller_model = nil, foreign_key = nil)
+    def persist_with_relationships(meta, attributes, relationships, caller_model = nil, foreign_key = nil, assigned_model: nil)
       persistence = Graphiti::Util::Persistence \
-        .new(self, meta, attributes, relationships, caller_model, foreign_key)
+        .new(self, meta, attributes, relationships, caller_model, foreign_key,
+          assigned_model: assigned_model)
       persistence.run
     end
 

--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -123,6 +123,12 @@ module Graphiti
       adapter.disassociate(parent, child, association_name, type)
     end
 
+    def assign_with_relationships(meta, attributes, relationships, caller_model = nil, foreign_key = nil)
+      persistence = Graphiti::Util::Persistence \
+        .new(self, meta, attributes, relationships, caller_model, foreign_key)
+      persistence.assign
+    end
+
     def persist_with_relationships(meta, attributes, relationships, caller_model = nil, foreign_key = nil)
       persistence = Graphiti::Util::Persistence \
         .new(self, meta, attributes, relationships, caller_model, foreign_key)

--- a/lib/graphiti/resource/interface.rb
+++ b/lib/graphiti/resource/interface.rb
@@ -49,7 +49,16 @@ module Graphiti
         def build(params, base_scope = nil)
           validate_request!(params)
           runner = Runner.new(self, params)
-          runner.proxy(base_scope, single: true, raise_on_missing: true)
+          runner.proxy(base_scope, single: true, raise_on_missing: true).tap do |instance|
+            instance.assign_attributes(params) # assign the params to the underlying model
+          end
+        end
+
+        def load(models, base_scope = nil)
+          runner = Runner.new(self, {}, base_scope, :find)
+          runner.proxy(nil, bypass_required_filters: true).tap do |r|
+            r.data = models
+          end
         end
 
         private

--- a/lib/graphiti/resource/interface.rb
+++ b/lib/graphiti/resource/interface.rb
@@ -50,7 +50,16 @@ module Graphiti
         def build(params, base_scope = nil)
           validate_request!(params)
           runner = Runner.new(self, params)
-          runner.proxy(base_scope, single: true, raise_on_missing: true)
+          runner.proxy(base_scope, single: true, raise_on_missing: true).tap do |instance|
+            instance.assign_attributes(params) # assign the params to the underlying model
+          end
+        end
+
+        def load(models, base_scope = nil)
+          runner = Runner.new(self, {}, base_scope, :find)
+          runner.proxy(nil, bypass_required_filters: true).tap do |r|
+            r.data = models
+          end
         end
 
         private

--- a/lib/graphiti/resource/interface.rb
+++ b/lib/graphiti/resource/interface.rb
@@ -50,16 +50,7 @@ module Graphiti
         def build(params, base_scope = nil)
           validate_request!(params)
           runner = Runner.new(self, params)
-          runner.proxy(base_scope, single: true, raise_on_missing: true).tap do |instance|
-            instance.assign_attributes(params) # assign the params to the underlying model
-          end
-        end
-
-        def load(models, base_scope = nil)
-          runner = Runner.new(self, {}, base_scope, :find)
-          runner.proxy(nil, bypass_required_filters: true).tap do |r|
-            r.data = models
-          end
+          runner.proxy(base_scope, single: true, raise_on_missing: true, assign_action: :create)
         end
 
         private

--- a/lib/graphiti/resource/persistence.rb
+++ b/lib/graphiti/resource/persistence.rb
@@ -4,11 +4,11 @@ module Graphiti
       extend ActiveSupport::Concern
 
       class_methods do
-        def before_attributes(method = nil, only: [:create, :update, :assign], &blk)
+        def before_attributes(method = nil, only: [:create, :update], &blk)
           add_callback(:attributes, :before, method, only, &blk)
         end
 
-        def after_attributes(method = nil, only: [:create, :update, :assign], &blk)
+        def after_attributes(method = nil, only: [:create, :update], &blk)
           add_callback(:attributes, :after, method, only, &blk)
         end
 

--- a/lib/graphiti/resource/persistence.rb
+++ b/lib/graphiti/resource/persistence.rb
@@ -4,11 +4,11 @@ module Graphiti
       extend ActiveSupport::Concern
 
       class_methods do
-        def before_attributes(method = nil, only: [:create, :update], &blk)
+        def before_attributes(method = nil, only: [:create, :update, :assign], &blk)
           add_callback(:attributes, :before, method, only, &blk)
         end
 
-        def after_attributes(method = nil, only: [:create, :update], &blk)
+        def after_attributes(method = nil, only: [:create, :update, :assign], &blk)
           add_callback(:attributes, :after, method, only, &blk)
         end
 
@@ -69,15 +69,29 @@ module Graphiti
         end
       end
 
+      def assign(assign_params, meta = nil, action_name = nil)
+        id = assign_params[:id]
+        assign_params = assign_params.except(:id)
+        model_instance = nil
+
+        run_callbacks :attributes, action_name, assign_params, meta do |params|
+          model_instance = if action_name != :create && id
+            self.class._find(id: id).data
+          else
+            call_with_meta(:build, model, meta)
+          end
+          call_with_meta(:assign_attributes, model_instance, params, meta)
+          model_instance
+        end
+
+        model_instance
+      end
+
       def create(create_params, meta = nil)
         model_instance = nil
 
         run_callbacks :persistence, :create, create_params, meta do
-          run_callbacks :attributes, :create, create_params, meta do |params|
-            model_instance = call_with_meta(:build, model, meta)
-            call_with_meta(:assign_attributes, model_instance, params, meta)
-            model_instance
-          end
+          model_instance = assign(create_params, meta, :create)
 
           run_callbacks :save, :create, model_instance, meta do
             model_instance = call_with_meta(:save, model_instance, meta)
@@ -89,15 +103,9 @@ module Graphiti
 
       def update(update_params, meta = nil)
         model_instance = nil
-        id = update_params[:id]
-        update_params = update_params.except(:id)
 
         run_callbacks :persistence, :update, update_params, meta do
-          run_callbacks :attributes, :update, update_params, meta do |params|
-            model_instance = self.class._find(id: id).data
-            call_with_meta(:assign_attributes, model_instance, params, meta)
-            model_instance
-          end
+          model_instance = assign(update_params, meta, :update)
 
           run_callbacks :save, :update, model_instance, meta do
             model_instance = call_with_meta(:save, model_instance, meta)

--- a/lib/graphiti/resource/persistence.rb
+++ b/lib/graphiti/resource/persistence.rb
@@ -69,13 +69,19 @@ module Graphiti
         end
       end
 
-      def assign(assign_params, meta = nil, action_name = nil)
-        id = assign_params[:id]
-        assign_params = assign_params.except(:id)
-        model_instance = nil
+      # +model_instance+ is the already-built model from a previous #assign
+      # (see ResourceProxy#assign_attributes). When given, attributes are
+      # applied to it rather than to a freshly built/found model.
+      def assign(assign_params, meta = nil, action_name = nil, model_instance: nil)
+        # Only update strips :id (it identifies the record to find) - a create
+        # payload may legitimately carry a client-supplied id to assign.
+        if action_name == :update
+          id = assign_params[:id]
+          assign_params = assign_params.except(:id)
+        end
 
         run_callbacks :attributes, action_name, assign_params, meta do |params|
-          model_instance = if action_name != :create && id
+          model_instance ||= if action_name == :update
             self.class._find(id: id).data
           else
             call_with_meta(:build, model, meta)
@@ -87,29 +93,33 @@ module Graphiti
         model_instance
       end
 
-      def create(create_params, meta = nil)
-        model_instance = nil
+      # Attributes are assigned before the persistence callbacks fire, so
+      # around_persistence receives the assigned model - its pre-yield
+      # position is the last chance to touch the model before save, inside
+      # the transaction. Modify attributes in before_attributes instead.
+      def create(create_params, meta = nil, assigned_model: nil)
+        model_instance = assigned_model || assign(create_params, meta, :create)
 
-        run_callbacks :persistence, :create, create_params, meta do
-          model_instance = assign(create_params, meta, :create)
-
+        run_callbacks :persistence, :create, model_instance, meta do
           run_callbacks :save, :create, model_instance, meta do
             model_instance = call_with_meta(:save, model_instance, meta)
           end
 
           model_instance
         end
+
+        model_instance
       end
 
-      def update(update_params, meta = nil)
-        model_instance = nil
+      def update(update_params, meta = nil, assigned_model: nil)
+        model_instance = assigned_model || assign(update_params, meta, :update)
 
-        run_callbacks :persistence, :update, update_params, meta do
-          model_instance = assign(update_params, meta, :update)
-
+        run_callbacks :persistence, :update, model_instance, meta do
           run_callbacks :save, :update, model_instance, meta do
             model_instance = call_with_meta(:save, model_instance, meta)
           end
+
+          model_instance
         end
 
         model_instance

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -8,6 +8,7 @@ module Graphiti
       payload: nil,
       single: false,
       raise_on_missing: false,
+      data: nil,
       cache: nil,
       cache_expires_in: nil)
 
@@ -74,6 +75,11 @@ module Graphiti
       Renderer.new(self, options).as_graphql
     end
 
+    def data=(models)
+      @data = data
+      [@data].flatten.compact.each { |r| @resource.decorate_record(r) }
+    end
+
     def data
       @data ||= begin
         records = @scope.resolve
@@ -84,6 +90,7 @@ module Graphiti
         records
       end
     end
+
     alias_method :to_a, :data
     alias_method :resolve_data, :data
 
@@ -115,6 +122,16 @@ module Graphiti
 
     def pagination
       @pagination ||= Delegates::Pagination.new(self)
+    end
+
+    def assign_attributes(params = nil)
+      # deserialize params again?
+
+      @data = @resource.assign_with_relationships(
+        @payload.meta,
+        @payload.attributes,
+        @payload.relationships
+      )
     end
 
     def save(action: :create)
@@ -170,7 +187,7 @@ module Graphiti
       save(action: :update)
     end
 
-    alias update_attributes update # standard:disable Style/Alias
+    alias_method :update_attributes, :update
 
     def include_hash
       @include_hash ||= begin

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -11,6 +11,7 @@ module Graphiti
       payload: nil,
       single: false,
       raise_on_missing: false,
+      data: nil,
       cache: nil,
       cache_expires_in: nil,
       cache_tag: nil
@@ -80,6 +81,11 @@ module Graphiti
       Renderer.new(self, options).as_graphql
     end
 
+    def data=(models)
+      @data = data
+      [@data].flatten.compact.each { |r| @resource.decorate_record(r) }
+    end
+
     def data
       @data ||= begin
         records = @scope.resolve
@@ -89,6 +95,7 @@ module Graphiti
         records
       end
     end
+
     alias_method :to_a, :data
     alias_method :resolve_data, :data
 
@@ -129,6 +136,16 @@ module Graphiti
 
     def pagination
       @pagination ||= Delegates::Pagination.new(self)
+    end
+
+    def assign_attributes(params = nil)
+      # deserialize params again?
+
+      @data = @resource.assign_with_relationships(
+        @payload.meta,
+        @payload.attributes,
+        @payload.relationships
+      )
     end
 
     def save(action: :create)
@@ -184,7 +201,7 @@ module Graphiti
       save(action: :update)
     end
 
-    alias update_attributes update # standard:disable Style/Alias
+    alias_method :update_attributes, :update
 
     def include_hash
       @include_hash ||= begin

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -11,7 +11,7 @@ module Graphiti
       payload: nil,
       single: false,
       raise_on_missing: false,
-      data: nil,
+      assign_action: nil,
       cache: nil,
       cache_expires_in: nil,
       cache_tag: nil
@@ -23,6 +23,7 @@ module Graphiti
       @payload = payload
       @single = single
       @raise_on_missing = raise_on_missing
+      @assign_action = assign_action
       @cache = cache
       @cache_expires_in = cache_expires_in
       @cache_tag = cache_tag
@@ -81,13 +82,11 @@ module Graphiti
       Renderer.new(self, options).as_graphql
     end
 
-    def data=(models)
-      @data = data
-      [@data].flatten.compact.each { |r| @resource.decorate_record(r) }
-    end
-
     def data
-      @data ||= begin
+      return @data unless @data.nil?
+      return assign_attributes(@payload.params) if @assign_action
+
+      @data = begin
         records = @scope.resolve
         raise Graphiti::Errors::RecordNotFound if records.empty? && raise_on_missing?
 
@@ -138,13 +137,35 @@ module Graphiti
       @pagination ||= Delegates::Pagination.new(self)
     end
 
-    def assign_attributes(params = nil)
-      # deserialize params again?
+    # Apply request params to the underlying model without saving it,
+    # Rails-style: the params are always passed explicitly, in the same
+    # request-params shape find/build accept. They are validated,
+    # deserialized, and become the payload #save will persist.
+    #
+    # Idempotent per params - calling again with params that normalize to
+    # the same payload is a no-op, so the attributes callbacks fire once.
+    # Different params re-assign onto the same model instance.
+    #
+    # Note the attributes callbacks fire here, outside any transaction
+    # opened during #save - the persistence hooks wrap only the save phase,
+    # receiving this assigned model.
+    def assign_attributes(params)
+      action = @assign_action || :update
+      params = normalized_params_copy(params)
+      add_endpoint_filter(params, action)
+      validator = ::Graphiti::RequestValidator.new(@resource, params, action)
+      validator.validate!
 
-      @data = @resource.assign_with_relationships(
-        @payload.meta,
+      if @assigned_model && same_write_payload?(validator.deserialized_payload)
+        return @assigned_model
+      end
+
+      @payload = validator.deserialized_payload
+      @assigned_model = @data = @resource.assign_with_relationships(
+        @payload.meta(action: action),
         @payload.attributes,
-        @payload.relationships
+        @payload.relationships,
+        model_instance: @assigned_model || (data if action == :update)
       )
     end
 
@@ -154,12 +175,18 @@ module Graphiti
       original = Graphiti.context[:namespace]
       begin
         Graphiti.context[:namespace] = action
-        ::Graphiti::RequestValidator.new(@resource, @payload.params, action).validate!
+        # An assigned model can only come from #assign_attributes, which
+        # validated the payload it stored - re-validating here would run the
+        # writable guards (and their guard_model lookups) a redundant time.
+        unless @assigned_model
+          ::Graphiti::RequestValidator.new(@resource, @payload.params, action).validate!
+        end
         validator = persist {
           @resource.persist_with_relationships \
             @payload.meta(action: action),
             @payload.attributes,
-            @payload.relationships
+            @payload.relationships,
+            assigned_model: @assigned_model
         }
       ensure
         Graphiti.context[:namespace] = original
@@ -257,6 +284,39 @@ module Graphiti
     end
 
     private
+
+    # Validation typecasts values and injects ids into the params it is
+    # given - work on a deep copy so the caller's hash stays untouched.
+    def normalized_params_copy(params)
+      if params.respond_to?(:to_unsafe_h)
+        params.to_unsafe_h.deep_symbolize_keys
+      else
+        ::Graphiti::Util::Hash.deep_dup(params)
+      end
+    end
+
+    # UpdateValidator enforces that data.id matches the endpoint's filter id.
+    # Params that came through find already carry that filter; params passed
+    # directly to #assign_attributes usually don't, so merge in the id this
+    # proxy was found with. A payload whose data.id names a different record
+    # still fails validation with ConflictRequest. Mutates the copy made by
+    # #normalized_params_copy, never caller state.
+    def add_endpoint_filter(params, action)
+      return unless action == :update
+
+      endpoint_id = @query.filters[:id]
+      return if endpoint_id.nil? || params[:filter].try(:[], :id)
+
+      params[:filter] ||= {}
+      params[:filter][:id] = endpoint_id
+    end
+
+    # Compare only the write payload (data + included) - a repeat call whose
+    # params differ in read-side keys like sort or page is still a no-op.
+    def same_write_payload?(deserialized_payload)
+      deserialized_payload.params.values_at(:data, :included) ==
+        @payload.params.values_at(:data, :included)
+    end
 
     def persist
       transaction_response = @resource.transaction do

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -223,7 +223,11 @@ module Graphiti
       success
     end
 
-    def update
+    # Rails-style: pass params to assign and save in one call, or call with
+    # no arguments to save a payload assigned earlier (via find or
+    # #assign_attributes).
+    def update(params = nil)
+      assign_attributes(params) if params
       resolve_data
       save(action: :update)
     end

--- a/lib/graphiti/runner.rb
+++ b/lib/graphiti/runner.rb
@@ -8,7 +8,6 @@ module Graphiti
       @params = params
       @query = query
       @action = action
-
       validator = RequestValidator.new(jsonapi_resource, params, action)
       validator.validate!
 
@@ -72,6 +71,7 @@ module Graphiti
         payload: deserialized_payload,
         single: opts[:single],
         raise_on_missing: opts[:raise_on_missing],
+        data: opts[:data],
         cache: opts[:cache],
         cache_expires_in: opts[:cache_expires_in]
     end

--- a/lib/graphiti/runner.rb
+++ b/lib/graphiti/runner.rb
@@ -8,7 +8,6 @@ module Graphiti
       @params = params
       @query = query
       @action = action
-
       validator = RequestValidator.new(jsonapi_resource, params, action)
       validator.validate!
 
@@ -77,6 +76,7 @@ module Graphiti
         payload: deserialized_payload,
         single: opts[:single],
         raise_on_missing: opts[:raise_on_missing],
+        data: opts[:data],
         cache: opts[:cache],
         cache_expires_in: opts[:cache_expires_in],
         cache_tag: opts[:cache_tag]

--- a/lib/graphiti/runner.rb
+++ b/lib/graphiti/runner.rb
@@ -76,7 +76,7 @@ module Graphiti
         payload: deserialized_payload,
         single: opts[:single],
         raise_on_missing: opts[:raise_on_missing],
-        data: opts[:data],
+        assign_action: opts[:assign_action],
         cache: opts[:cache],
         cache_expires_in: opts[:cache_expires_in],
         cache_tag: opts[:cache_tag]

--- a/lib/graphiti/serializer.rb
+++ b/lib/graphiti/serializer.rb
@@ -100,6 +100,7 @@ module Graphiti
     def strip_relationships?
       return false unless Graphiti.config.links_on_demand
       params = Graphiti.context[:object]&.params || {}
+
       [false, nil, "false"].include?(params[:links])
     end
   end

--- a/lib/graphiti/serializer.rb
+++ b/lib/graphiti/serializer.rb
@@ -103,6 +103,7 @@ module Graphiti
     def strip_relationships?
       return false unless Graphiti.config.links_on_demand
       params = Graphiti.context[:object]&.params || {}
+
       [false, nil, "false"].include?(params[:links])
     end
   end

--- a/lib/graphiti/util/hash.rb
+++ b/lib/graphiti/util/hash.rb
@@ -55,8 +55,15 @@ module Graphiti
         else
           {}.tap do |duped|
             hash.each_pair do |key, value|
-              value = deep_dup(value) if value.is_a?(Hash)
-              value = value.dup if value&.respond_to?(:dup) && ![Symbol, Integer].include?(value.class)
+              value = if value.is_a?(Hash)
+                deep_dup(value)
+              elsif value.is_a?(Array)
+                value.map { |element| element.is_a?(Hash) ? deep_dup(element) : element }
+              elsif value&.respond_to?(:dup) && ![Symbol, Integer].include?(value.class)
+                value.dup
+              else
+                value
+              end
               duped[key] = value
             end
           end

--- a/lib/graphiti/util/persistence.rb
+++ b/lib/graphiti/util/persistence.rb
@@ -24,6 +24,14 @@ class Graphiti::Util::Persistence
     end
   end
 
+  def assign
+    attributes = @adapter.persistence_attributes(self, @attributes)
+    assigned = @resource.assign(attributes, @meta, :assign)
+    @resource.decorate_record(assigned)
+
+    assigned
+  end
+
   # Perform the actual save logic.
   #
   # belongs_to must be processed before/separately from has_many -
@@ -49,8 +57,8 @@ class Graphiti::Util::Persistence
     parents = @adapter.process_belongs_to(self, attributes)
     persisted = persist_object(@meta[:method], attributes)
     @resource.decorate_record(persisted)
-    assign_temp_id(persisted, @meta[:temp_id])
 
+    assign_temp_id(persisted, @meta[:temp_id])
     associate_parents(persisted, parents)
 
     children = @adapter.process_has_many(self, persisted)
@@ -129,6 +137,8 @@ class Graphiti::Util::Persistence
 
   def persist_object(method, attributes)
     case method
+      when :assign
+        call_resource_method(:assign, attributes, @caller_model)
       when :destroy
         call_resource_method(:destroy, attributes[:id], @caller_model)
       when :update, nil, :disassociate

--- a/lib/graphiti/util/persistence.rb
+++ b/lib/graphiti/util/persistence.rb
@@ -7,8 +7,12 @@ class Graphiti::Util::Persistence
   # @param [Hash] relationships see (Deserializer#relationships)
   # @param [Model] caller_model The persisted parent object in the request graph
   # @param [Symbol] foreign_key Attribute assigned by parent object in graph
-  def initialize(resource, meta, attributes, relationships, caller_model, foreign_key = nil)
+  # @param [Model] assigned_model a model already built by #assign, to be
+  #   assigned onto rather than rebuilt
+  # TODO: make foreign_key a keyword once the satellite gems are rolled in
+  def initialize(resource, meta, attributes, relationships, caller_model, foreign_key = nil, assigned_model: nil)
     @resource = resource
+    @assigned_model = assigned_model
     @meta = meta
     @attributes = attributes
     @relationships = relationships
@@ -26,7 +30,7 @@ class Graphiti::Util::Persistence
 
   def assign
     attributes = @adapter.persistence_attributes(self, @attributes)
-    assigned = @resource.assign(attributes, @meta, :assign)
+    assigned = @resource.assign(attributes, metadata, @meta[:method], model_instance: @assigned_model)
     @resource.decorate_record(assigned)
 
     assigned
@@ -54,7 +58,9 @@ class Graphiti::Util::Persistence
   def run
     attributes = @adapter.persistence_attributes(self, @attributes)
 
+    payload_attributes = attributes.dup
     parents = @adapter.process_belongs_to(self, attributes)
+    apply_derived_attributes(attributes, payload_attributes)
     persisted = persist_object(@meta[:method], attributes)
     @resource.decorate_record(persisted)
 
@@ -88,6 +94,19 @@ class Graphiti::Util::Persistence
   end
 
   private
+
+  # process_belongs_to persists the parents and writes their primary keys into
+  # +attributes+. A model that was already assigned (see ResourceProxy#assign_attributes)
+  # predates those keys, so apply just them - the payload attributes are already on it,
+  # and re-applying them would clobber any changes made since.
+  def apply_derived_attributes(attributes, payload_attributes)
+    return unless @assigned_model
+
+    derived = attributes.reject { |key, value| payload_attributes[key] == value }
+    return if derived.empty?
+
+    @resource.assign_attributes(@assigned_model, derived, metadata)
+  end
 
   def add_hook(prc, lifecycle_event)
     ::Graphiti::Util::TransactionHooksRecorder.add(prc, lifecycle_event)
@@ -137,8 +156,6 @@ class Graphiti::Util::Persistence
 
   def persist_object(method, attributes)
     case method
-      when :assign
-        call_resource_method(:assign, attributes, @caller_model)
       when :destroy
         call_resource_method(:destroy, attributes[:id], @caller_model)
       when :update, nil, :disassociate
@@ -173,10 +190,19 @@ class Graphiti::Util::Persistence
     }
   end
 
+  def accepts_assigned_model?(method)
+    method.parameters.any? { |type, name| name == :assigned_model && [:key, :keyreq].include?(type) }
+  end
+
   def call_resource_method(method_name, attributes, caller_model)
     method = @resource.method(method_name)
 
-    if method.arity == 1
+    if @assigned_model && [:create, :update].include?(method_name)
+      unless accepts_assigned_model?(method)
+        raise Graphiti::Errors::AssignedModelNotSupported.new(@resource.class, method_name)
+      end
+      method.call(attributes, metadata, assigned_model: @assigned_model)
+    elsif method.arity == 1
       method.call(attributes)
     else
       method.call(attributes, metadata)

--- a/spec/integration/rails/callbacks_spec.rb
+++ b/spec/integration/rails/callbacks_spec.rb
@@ -8,6 +8,7 @@ if ENV["APPRAISAL_INITIALIZED"]
 
       routes.draw do
         post "create" => "anonymous#create"
+        put "update" => "anonymous#update"
         delete "destroy" => "anonymous#destroy"
       end
 
@@ -34,6 +35,7 @@ if ENV["APPRAISAL_INITIALIZED"]
 
       class EmployeeResource < ApplicationResource
         self.model = Employee
+        self.type = "employees"
 
         before_attributes :one
         before_attributes :two
@@ -168,6 +170,18 @@ if ENV["APPRAISAL_INITIALIZED"]
         end
       end
 
+      def update
+        employee = IntegrationCallbacks::EmployeeResource._find(params)
+        Thread.current[:proxy] = employee
+        employee.assign_attributes
+
+        if employee.update_attributes
+          render jsonapi: employee
+        else
+          raise "whoops"
+        end
+      end
+
       def destroy
         employee = IntegrationCallbacks::EmployeeResource._find(params)
         Thread.current[:proxy] = employee
@@ -222,6 +236,39 @@ if ENV["APPRAISAL_INITIALIZED"]
           it "rolls back the transaction" do
             expect {
               expect { post :create, params: payload }.to raise_error("test")
+            }.to_not(change { Employee.count })
+          end
+        end
+      end
+
+      describe "update callbacks" do
+        let!(:employee) { Employee.create!(first_name: "asdf") }
+        let(:payload) {
+          {id: employee.id,
+           data: {
+             id: employee.id,
+             type: "employees",
+             attributes: {first_name: "Jane"}
+           }}
+        }
+
+        it "fires hooks in order" do
+          expect {
+            put :update, params: payload
+          }.to change { Employee.find(employee.id).first_name }
+          employee = proxy.data
+          expect(employee.first_name)
+            .to eq("Jane5a6a7a12347b6b5b_12a_13a_14a89_10_11_14b_13b_12b")
+        end
+
+        context "when an error is raised" do
+          before do
+            $raise = true
+          end
+
+          it "rolls back the transaction" do
+            expect {
+              expect { put :update, params: payload }.to raise_error("test")
             }.to_not(change { Employee.count })
           end
         end

--- a/spec/integration/rails/callbacks_spec.rb
+++ b/spec/integration/rails/callbacks_spec.rb
@@ -173,7 +173,7 @@ if ENV["APPRAISAL_INITIALIZED"]
       def update
         employee = IntegrationCallbacks::EmployeeResource._find(params)
         Thread.current[:proxy] = employee
-        employee.assign_attributes
+        employee.assign_attributes(params)
 
         if employee.update_attributes
           render jsonapi: employee

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -1748,4 +1748,78 @@ if ENV["APPRAISAL_INITIALIZED"]
       end
     end
   end
+
+  # Applying the payload without saving lets a controller inspect ActiveRecord's
+  # dirty tracking to decide whether the update is permitted at all.
+  # type: :controller only to opt into the DatabaseCleaner hooks in spec_helper
+  RSpec.describe "applying a payload without saving", type: :controller do
+    let!(:employee) { Employee.create!(first_name: "Joe", last_name: "Smith") }
+
+    let(:payload) do
+      {
+        id: employee.id,
+        data: {
+          id: employee.id.to_s,
+          type: "employees",
+          attributes: {first_name: "Jane"}
+        }
+      }
+    end
+
+    around do |e|
+      Graphiti.with_context({}, :update) { e.run }
+    end
+
+    it "leaves the record clean before the payload is applied" do
+      proxy = EmployeeResource.find(payload)
+
+      expect(proxy.data.changed).to eq([])
+      expect(proxy.data.first_name).to eq("Joe")
+    end
+
+    it "reports the changed attributes once the payload is applied" do
+      proxy = EmployeeResource.find(payload)
+      proxy.assign_attributes(payload)
+
+      expect(proxy.data.changed).to eq(["first_name"])
+      expect(proxy.data.first_name_was).to eq("Joe")
+      expect(proxy.data).to be_changed
+    end
+
+    it "does not touch the database" do
+      proxy = EmployeeResource.find(payload)
+      proxy.assign_attributes(payload)
+
+      expect(employee.reload.first_name).to eq("Joe")
+    end
+
+    it "reports the same changes when applied more than once" do
+      proxy = EmployeeResource.find(payload)
+      proxy.assign_attributes(payload)
+      proxy.assign_attributes(payload)
+
+      expect(proxy.data.changed).to eq(["first_name"])
+    end
+
+    it "commits the pending changes on update_attributes" do
+      proxy = EmployeeResource.find(payload)
+      proxy.assign_attributes(payload)
+
+      expect {
+        expect(proxy.update_attributes).to eq(true)
+      }.to change { employee.reload.first_name }.from("Joe").to("Jane")
+
+      expect(proxy.data.changed).to eq([])
+    end
+
+    it "surfaces validation errors without saving" do
+      payload[:data][:attributes][:first_name] = nil
+      proxy = EmployeeResource.find(payload)
+      proxy.assign_attributes(payload)
+
+      expect(proxy.data.valid?).to eq(false)
+      expect(proxy.data.errors.full_messages).to eq(["First name can't be blank"])
+      expect(employee.reload.first_name).to eq("Joe")
+    end
+  end
 end

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -37,6 +37,22 @@ RSpec.describe "persistence" do
     expect(employee.data.first_name).to eq("Jane")
   end
 
+  it "can access the unsaved model after build" do
+    employee = klass.build(payload)
+    expect(employee.data).to_not be_nil
+    expect(employee.data.first_name).to eq("Jane")
+    expect(employee.data.id).to be_nil
+  end
+
+  xit "can modify attributes directly on the unsaved model before save" do
+    employee = klass.build(payload)
+    expect(employee.data).to_not be_nil
+    employee.data.first_name = "June"
+
+    expect(employee.save).to eq(true)
+    expect(employee.data.first_name).to eq("June")
+  end
+
   describe "updating" do
     let!(:employee) { PORO::Employee.create(first_name: "asdf") }
 
@@ -51,6 +67,16 @@ RSpec.describe "persistence" do
           employee.update_attributes
         }.to raise_error(Graphiti::Errors::RecordNotFound)
       end
+    end
+
+    it "can apply attributes and access model" do
+      employee = klass.find(payload)
+      expect(employee.data.first_name).to eq("asdf")
+      employee.assign_attributes
+      expect(employee.data.first_name).to eq("Jane")
+
+      employee = klass.find(payload)
+      expect(employee.data.first_name).to eq("asdf")
     end
   end
 
@@ -1825,8 +1851,8 @@ RSpec.describe "persistence" do
 
     context "and it is a create operation" do
       it "works" do
-        instance = klass.build(payload)
         expect {
+          instance = klass.build(payload)
           instance.save
         }.to raise_error(Graphiti::Errors::InvalidRequest, /data.attributes.id/)
       end

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -37,6 +37,19 @@ RSpec.describe "persistence" do
     expect(employee.data.first_name).to eq("Jane")
   end
 
+  it "keeps a client-supplied id on create" do
+    captured_attributes = nil
+    klass.before_attributes do |attributes|
+      captured_attributes = attributes.dup
+    end
+    payload[:data][:id] = "789"
+
+    employee = klass.build(payload)
+
+    expect(employee.data.id).to eq(789)
+    expect(captured_attributes[:id]).to eq(789)
+  end
+
   it "can access the unsaved model after build" do
     employee = klass.build(payload)
     expect(employee.data).to_not be_nil
@@ -44,13 +57,407 @@ RSpec.describe "persistence" do
     expect(employee.data.id).to be_nil
   end
 
-  xit "can modify attributes directly on the unsaved model before save" do
+  it "can modify attributes directly on the unsaved model before save" do
     employee = klass.build(payload)
     expect(employee.data).to_not be_nil
     employee.data.first_name = "June"
 
     expect(employee.save).to eq(true)
     expect(employee.data.first_name).to eq("June")
+  end
+
+  # Controllers use this to answer "what would happen if I saved this?" - render
+  # the model with the payload applied, or its validation errors, without touching
+  # the database. See also the "dry run" specs in spec/integration/rails.
+  describe "inspecting the model before saving" do
+    let(:callback_passes) { [] }
+    let(:klass) do
+      passes = callback_passes
+      Class.new(PORO::EmployeeResource) do
+        self.model = PORO::Employee
+
+        before_attributes do |attributes|
+          passes << attributes
+          attributes
+        end
+
+        def self.name
+          "PORO::EmployeeResource"
+        end
+      end
+    end
+
+    describe "writable guard evaluation" do
+      let(:klass) do
+        Class.new(PORO::EmployeeResource) do
+          self.model = PORO::Employee
+
+          def self.name
+            "PORO::EmployeeResource"
+          end
+
+          class << self
+            attr_accessor :guard_calls
+          end
+          self.guard_calls = 0
+
+          attribute :first_name, :string, writable: :first_name_writable?
+
+          def first_name_writable?(_model = nil, _attribute = nil)
+            self.class.guard_calls += 1
+            true
+          end
+        end
+      end
+
+      # Guards run once when the proxy is built and once during
+      # #assign_attributes. #save skips re-validating the payload it already
+      # validated, so inspecting the model costs no extra guard evaluations
+      # over the plain-save path.
+      it "does not re-run guards at save time" do
+        employee = klass.build(payload)
+        employee.data
+        calls_after_assign = klass.guard_calls
+
+        expect(employee.save).to eq(true)
+        expect(klass.guard_calls).to eq(calls_after_assign)
+      end
+
+      it "still runs guards at save time on the plain-save path" do
+        employee = klass.build(payload)
+        calls_before_save = klass.guard_calls
+
+        expect(employee.save).to eq(true)
+        expect(klass.guard_calls).to eq(calls_before_save + 1)
+      end
+    end
+
+    describe "on create" do
+      it "exposes an unsaved model without persisting it" do
+        employee = klass.build(payload)
+
+        expect(employee.data.first_name).to eq("Jane")
+        expect(employee.data.id).to be_nil
+        expect(employee.data.valid?).to eq(true)
+        expect(PORO::DB.data[:employees]).to be_empty
+      end
+
+      it "runs the attributes callbacks once, no matter how often data is read" do
+        employee = klass.build(payload)
+
+        3.times { employee.data }
+        employee.assign_attributes(payload)
+        employee.save
+
+        expect(callback_passes.length).to eq(1)
+      end
+
+      it "returns the same model instance every time" do
+        employee = klass.build(payload)
+        expect(employee.data).to equal(employee.data)
+      end
+
+      it "exposes validation errors without persisting" do
+        klass.model = Class.new(PORO::Employee) {
+          validates :first_name, presence: true
+
+          def self.name
+            "PORO::Employee"
+          end
+        }
+        payload[:data][:attributes] = {first_name: nil}
+
+        employee = klass.build(payload)
+
+        expect(employee.data.valid?).to eq(false)
+        expect_errors(employee.data, ["First name can't be blank"])
+        expect(PORO::DB.data[:employees]).to be_empty
+      end
+
+      it "still persists after the model has been inspected" do
+        employee = klass.build(payload)
+        employee.data
+
+        expect(employee.save).to eq(true)
+        expect(employee.data.id).to_not be_nil
+      end
+
+      # The persistence callbacks receive a frozen copy of the attributes
+      # (see Resource::Persistence#create) - the payload itself must stay
+      # mutable for anything reading it after save, e.g. after_commit hooks.
+      it "does not leave the payload attributes frozen after save" do
+        employee = klass.build(payload)
+        employee.data
+        employee.save
+
+        expect(employee.payload.attributes).to_not be_frozen
+      end
+    end
+
+    describe "on update" do
+      let!(:employee) { PORO::Employee.create(first_name: "asdf") }
+
+      before do
+        payload[:data][:id] = employee.id.to_s
+      end
+
+      it "reads the persisted model until the payload is applied" do
+        proxy = klass.find(payload)
+        expect(proxy.data.first_name).to eq("asdf")
+
+        proxy.assign_attributes(payload)
+        expect(proxy.data.first_name).to eq("Jane")
+      end
+
+      it "does not persist the applied payload" do
+        klass.find(payload).assign_attributes(payload)
+
+        expect(PORO::Employee.find(employee.id).first_name).to eq("asdf")
+      end
+
+      it "runs the attributes callbacks once across repeated calls" do
+        proxy = klass.find(payload)
+
+        proxy.data
+        proxy.assign_attributes(payload)
+        proxy.assign_attributes(payload)
+
+        expect(callback_passes.length).to eq(1)
+      end
+
+      it "assigns onto the already-resolved model rather than reloading it" do
+        proxy = klass.find(payload)
+        resolved = proxy.data
+
+        expect(proxy.assign_attributes(payload)).to equal(resolved)
+      end
+
+      it "re-assigns onto the same model when called with different params" do
+        proxy = klass.find(payload)
+        first_assigned = proxy.assign_attributes(payload)
+
+        new_payload = {data: {type: "employees", id: employee.id.to_s, attributes: {first_name: "June"}}}
+        second_assigned = proxy.assign_attributes(new_payload)
+
+        expect(second_assigned).to equal(first_assigned)
+        expect(proxy.data.first_name).to eq("June")
+        expect(proxy.update_attributes).to eq(true)
+        expect(PORO::Employee.find(employee.id).first_name).to eq("June")
+      end
+
+      it "supports Rails-style find-then-assign" do
+        proxy = klass.find(id: employee.id.to_s)
+        proxy.assign_attributes(payload)
+
+        expect(proxy.data.first_name).to eq("Jane")
+        expect(PORO::Employee.find(employee.id).first_name).to eq("asdf")
+      end
+
+      it "does not re-assign when only read-side query params differ" do
+        proxy = klass.find(payload)
+        proxy.assign_attributes(payload)
+        proxy.assign_attributes(payload.merge(sort: "-id"))
+
+        expect(callback_passes.length).to eq(1)
+      end
+
+      it "does not mutate the params passed by the caller" do
+        original = {data: {type: "employees", id: employee.id.to_s, attributes: {first_name: "Jill"}}}
+        snapshot = Marshal.load(Marshal.dump(original))
+
+        proxy = klass.find(id: employee.id.to_s)
+        proxy.assign_attributes(original)
+
+        expect(original).to eq(snapshot)
+      end
+
+      it "persists once the payload has already been applied" do
+        proxy = klass.find(payload)
+        proxy.assign_attributes(payload)
+
+        expect(proxy.update_attributes).to eq(true)
+        expect(PORO::Employee.find(employee.id).first_name).to eq("Jane")
+        expect(callback_passes.length).to eq(1)
+      end
+
+      it "keeps changes made to the model after the payload was applied" do
+        proxy = klass.find(payload)
+        proxy.assign_attributes(payload)
+        proxy.data.first_name = "June"
+
+        expect(proxy.update_attributes).to eq(true)
+        expect(PORO::Employee.find(employee.id).first_name).to eq("June")
+      end
+
+      it "can modify the model for rendering without persisting" do
+        proxy = klass.find(payload)
+        proxy.data.first_name = "June"
+
+        expect(proxy.data.first_name).to eq("June")
+        expect(PORO::Employee.find(employee.id).first_name).to eq("asdf")
+      end
+    end
+
+    # Attributes are assigned before the persistence callbacks fire, so
+    # around_persistence receives the assigned model - its pre-yield position
+    # is the last chance to modify the model before save.
+    describe "with an around_persistence hook" do
+      context "that modifies the model before yielding" do
+        before do
+          klass.class_eval do
+            around_persistence :do_around_persistence
+
+            def do_around_persistence(model)
+              model.first_name = "hooked"
+              yield
+            end
+          end
+        end
+
+        it "persists the pre-yield change on create" do
+          employee = klass.build(payload)
+
+          expect(employee.save).to eq(true)
+          expect(PORO::Employee.find(employee.data.id).first_name).to eq("hooked")
+        end
+
+        it "receives the same instance the caller inspected" do
+          employee = klass.build(payload)
+          inspected = employee.data
+
+          expect(employee.save).to eq(true)
+          expect(employee.data).to equal(inspected)
+          expect(PORO::Employee.find(employee.data.id).first_name).to eq("hooked")
+        end
+
+        it "persists the pre-yield change on update" do
+          existing = PORO::Employee.create(first_name: "asdf")
+          payload[:data][:id] = existing.id.to_s
+
+          proxy = klass.find(payload)
+          proxy.assign_attributes(payload)
+
+          expect(proxy.update_attributes).to eq(true)
+          expect(PORO::Employee.find(existing.id).first_name).to eq("hooked")
+        end
+      end
+
+      context "that only wraps the save" do
+        before do
+          klass.class_eval do
+            around_persistence :do_around_persistence
+
+            def do_around_persistence(model)
+              saved = yield
+              saved.update_attributes(first_name: "#{saved.first_name}after")
+            end
+          end
+        end
+
+        it "works after the model has been inspected" do
+          employee = klass.build(payload)
+          employee.data
+
+          expect(employee.save).to eq(true)
+          expect(PORO::Employee.find(employee.data.id).first_name).to eq("Janeafter")
+        end
+      end
+
+      context "that raises FrozenError on some other object" do
+        before do
+          klass.class_eval do
+            around_persistence :do_around_persistence
+
+            def do_around_persistence(attributes)
+              "frozen".freeze << "oops"
+              yield
+            end
+          end
+        end
+
+        it "propagates the original error untouched" do
+          employee = klass.build(payload)
+          employee.data
+
+          expect {
+            employee.save
+          }.to raise_error(FrozenError, /can't modify frozen String/)
+        end
+      end
+
+      context "that raises a FrozenError constructed without a receiver" do
+        before do
+          klass.class_eval do
+            around_persistence :do_around_persistence
+
+            def do_around_persistence(attributes)
+              raise FrozenError, "custom frozen boom"
+            end
+          end
+        end
+
+        it "propagates the original error untouched" do
+          employee = klass.build(payload)
+          employee.data
+
+          expect {
+            employee.save
+          }.to raise_error(FrozenError, "custom frozen boom")
+        end
+
+        it "propagates it on the one-shot path too" do
+          expect {
+            klass.build(payload).save
+          }.to raise_error(FrozenError, "custom frozen boom")
+        end
+      end
+    end
+
+    describe "with an overridden create/update" do
+      context "when the override cannot receive the assigned model" do
+        before do
+          klass.class_eval do
+            def create(attributes, meta = nil)
+              super
+            end
+          end
+        end
+
+        it "raises instead of silently dropping changes made to the unsaved model" do
+          employee = klass.build(payload)
+          employee.data.first_name = "June"
+
+          expect {
+            employee.save
+          }.to raise_error(Graphiti::Errors::AssignedModelNotSupported, /create/)
+        end
+
+        it "still works on the one-shot path" do
+          employee = klass.build(payload)
+
+          expect(employee.save).to eq(true)
+          expect(employee.data.first_name).to eq("Jane")
+        end
+      end
+
+      context "when the override accepts the assigned_model keyword" do
+        before do
+          klass.class_eval do
+            def create(attributes, meta = nil, assigned_model: nil)
+              super
+            end
+          end
+        end
+
+        it "passes the assigned model through" do
+          employee = klass.build(payload)
+          employee.data.first_name = "June"
+
+          expect(employee.save).to eq(true)
+          expect(PORO::Employee.find(employee.data.id).first_name).to eq("June")
+        end
+      end
+    end
   end
 
   describe "updating" do
@@ -72,7 +479,7 @@ RSpec.describe "persistence" do
     it "can apply attributes and access model" do
       employee = klass.find(payload)
       expect(employee.data.first_name).to eq("asdf")
-      employee.assign_attributes
+      employee.assign_attributes(payload)
       expect(employee.data.first_name).to eq("Jane")
 
       employee = klass.find(payload)
@@ -689,8 +1096,8 @@ RSpec.describe "persistence" do
               attrs[:first_name] = "#{attrs[:first_name]}mid"
             end
 
-            def do_around_persistence(attributes)
-              attributes[:first_name] = "b4"
+            def do_around_persistence(model)
+              model.first_name = "b4"
               model = yield
               model.update_attributes(first_name: "#{model.first_name}after")
               1 # return value shouldnt matter
@@ -713,7 +1120,7 @@ RSpec.describe "persistence" do
 
             it "can modify attributes and the saved model" do
               reloaded = PORO::Employee.find(employee.id)
-              expect(reloaded.first_name).to eq("b4midafter")
+              expect(reloaded.first_name).to eq("b4after")
             end
           end
         end
@@ -723,7 +1130,7 @@ RSpec.describe "persistence" do
 
           it "can modify attributes and the saved model" do
             reloaded = PORO::Employee.find(employee.id)
-            expect(reloaded.first_name).to eq("b4midafter")
+            expect(reloaded.first_name).to eq("b4after")
           end
         end
       end
@@ -1141,21 +1548,21 @@ RSpec.describe "persistence" do
             model.first_name << "_aroundsaveC2"
           end
 
-          def around_persistence_a(attrs)
-            attrs[:first_name] << "_aroundpersA1"
-            model = yield attrs
+          def around_persistence_a(model)
+            model.first_name << "_aroundpersA1"
+            model = yield model
             model.first_name << "_aroundpersA2"
           end
 
-          def around_persistence_b(attrs)
-            attrs[:first_name] << "_aroundpersB1"
-            model = yield attrs
+          def around_persistence_b(model)
+            model.first_name << "_aroundpersB1"
+            model = yield model
             model.first_name << "_aroundpersB2"
           end
 
-          def around_persistence_c(attrs)
-            attrs[:first_name] << "_aroundpersC1"
-            model = yield attrs
+          def around_persistence_c(model)
+            model.first_name << "_aroundpersC1"
+            model = yield model
             model.first_name << "_aroundpersC2"
           end
         end
@@ -1166,8 +1573,6 @@ RSpec.describe "persistence" do
         proxy.save
         expect(proxy.data.first_name.split("_")).to eq([
           "Jane",
-          "aroundpersA1",
-          "aroundpersB1",
           "aroundattrsA1",
           "aroundattrsB1",
           "b4attrsA",
@@ -1176,6 +1581,8 @@ RSpec.describe "persistence" do
           "afterattrsB",
           "aroundattrsB2",
           "aroundattrsA2",
+          "aroundpersA1",
+          "aroundpersB1",
           "aroundsaveA1",
           "aroundsaveB1",
           "b4saveA",
@@ -1196,9 +1603,6 @@ RSpec.describe "persistence" do
         proxy.update_attributes
         expect(proxy.data.first_name.split("_")).to eq([
           "Jane",
-          "aroundpersA1",
-          "aroundpersB1",
-          "aroundpersC1",
           "aroundattrsA1",
           "aroundattrsB1",
           "aroundattrsC1",
@@ -1211,6 +1615,9 @@ RSpec.describe "persistence" do
           "aroundattrsC2",
           "aroundattrsB2",
           "aroundattrsA2",
+          "aroundpersA1",
+          "aroundpersB1",
+          "aroundpersC1",
           "aroundsaveA1",
           "aroundsaveB1",
           "aroundsaveC1",
@@ -2410,6 +2817,16 @@ RSpec.describe "persistence" do
         expect(data.classification).to be_a(classification_model)
         expect(data.classification.id).to be_present
         expect(data.classification.description).to eq("classy")
+      end
+
+      it "works when the model is inspected before save" do
+        employee = klass.build(payload)
+        employee.data # force assignment
+        expect(employee.save).to eq(true)
+        data = employee.data
+        expect(data.id).to be_present
+        expect(data.classification).to be_a(classification_model)
+        expect(data.classification_id).to eq(data.classification.id)
       end
 
       context "when a nested validation error" do

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -330,6 +330,15 @@ RSpec.describe "persistence" do
           expect(PORO::Employee.find(employee.data.id).first_name).to eq("hooked")
         end
 
+        it "assigns and saves in one call when update is given params" do
+          existing = PORO::Employee.create(first_name: "asdf")
+          payload[:data][:id] = existing.id.to_s
+
+          proxy = klass.find(payload)
+          expect(proxy.update(payload)).to eq(true)
+          expect(PORO::Employee.find(existing.id).first_name).to eq("hooked")
+        end
+
         it "persists the pre-yield change on update" do
           existing = PORO::Employee.create(first_name: "asdf")
           payload[:data][:id] = existing.id.to_s


### PR DESCRIPTION
## Description

Today a resource goes straight from request payload to saved record — there is no point at which you can hold the model with attributes applied but nothing written. That makes ordinary Rails patterns awkward: inspecting what a request would change, running authorization against the resulting object, or adjusting an attribute before save.

This makes proxies assign lazily and exposes the unsaved model. The instance you inspect is the instance that saves — unconditionally.

### Creates

```ruby
resource = MyResource.build(params)
resource.data          # => unsaved model, attributes applied
resource.data.valid?   # inspect before committing to anything
resource.save
```

### Updates

```ruby
resource = MyResource.find(params)
resource.assign_attributes(params)  # Rails-style, takes request params
resource.data.changed               # dirty tracking works
resource.update

# or assign and save in one call, Rails-style
resource = MyResource.find(params)
resource.update(params)
```

### What changed

- `Resource.build(params)` returns a proxy whose `#data` is the built, attribute-applied model rather than resolving a scope (also fixes #458).
- `ResourceProxy#assign_attributes(params)` applies the payload to the model without saving. Idempotent per payload — repeated calls don't re-fire the attributes callbacks.
- Attributes are assigned once, before the persistence hooks fire. `save` persists the assigned instance; only `process_belongs_to`-derived foreign keys are applied at save time.
- Validation runs before assignment, and doesn't re-run at save when the payload was already validated — writable guards evaluate the same number of times whether or not you inspect the model.
- Ships `UPGRADING.md` in the gem.

### BREAKING CHANGES (hence the `beta` / 2.0 target)

**`around_persistence` receives the assigned model, not the attributes hash.** Its pre-yield position is now the last chance to touch the model before save, inside the transaction. Hooks that mutate the attributes hash before `yield` must move that change to `before_attributes` (same mutable-hash idiom, runs before assignment) or set it on the model. Hooks that only wrap their yield are unaffected. Graphiti 1.x warns at runtime for affected hooks (#514).

**Custom `create`/`update` overrides + inspected models.** If callers inspect the model before saving, the override must accept it: `def create(attributes, meta = nil, assigned_model: nil)`. Without the keyword, saving an inspected proxy raises `Graphiti::Errors::AssignedModelNotSupported` instead of silently discarding changes. Save-only usage is unaffected.

### Notes

- If you inspect the model before saving, the attributes callbacks run at inspection time, outside the save transaction. On the plain `save` path they run inside the transaction, at the same point as 1.x — save-only code sees no behavior change.
- Writable guards judge persisted state; they never see the current request's unsaved changes.
- `#data` exposes the pre-assigned root model; sideposted children are still built and assigned during save.
