### PR TITLE
Add thread pool and concurrency_max_threads configuration option

### DIFF
--- a/lib/graphiti/configuration.rb
+++ b/lib/graphiti/configuration.rb
@@ -7,8 +7,20 @@ module Graphiti
     # @return [Boolean] Concurrently fetch sideloads?
     #   Defaults to false OR if classes are cached (Rails-only)
     attr_accessor :concurrency
+    
+    # This number must be considered in accordance with the database
+    # connection pool size configured in `database.yml`. The connection
+    # pool should be large enough to accommodate both the foreground
+    # threads (ie. web server or job worker threads) and background
+    # threads. For each process, Graphiti will create one global
+    # executor that uses this many threads to sideload resources
+    # asynchronously. Thus, the pool size should be at least
+    # `thread_count + concurrency_max_threads + 1`. For example, if your
+    # web server has a maximum of 3 threads, and
+    # `concurrency_max_threads` is set to 4, then your pool size should
+    # be at least 8.
     # @return [Integer] Maximum number of threads to use when fetching sideloads concurrently
-    attr_accessor :concurrency_pool_max_size
+    attr_accessor :concurrency_max_threads
 
     attr_accessor :respond_to
     attr_accessor :context_for_endpoint
@@ -28,7 +40,7 @@ module Graphiti
     def initialize
       @raise_on_missing_sideload = true
       @concurrency = false
-      @concurrency_pool_max_size = 4
+      @concurrency_max_threads = 4
       @respond_to = [:json, :jsonapi, :xml]
       @links_on_demand = false
       @pagination_links_on_demand = false

--- a/lib/graphiti/configuration.rb
+++ b/lib/graphiti/configuration.rb
@@ -7,6 +7,8 @@ module Graphiti
     # @return [Boolean] Concurrently fetch sideloads?
     #   Defaults to false OR if classes are cached (Rails-only)
     attr_accessor :concurrency
+    # @return [Integer] Maximum number of threads to use when fetching sideloads concurrently
+    attr_accessor :concurrency_pool_max_size
 
     attr_accessor :respond_to
     attr_accessor :context_for_endpoint
@@ -26,6 +28,7 @@ module Graphiti
     def initialize
       @raise_on_missing_sideload = true
       @concurrency = false
+      @concurrency_pool_max_size = 4
       @respond_to = [:json, :jsonapi, :xml]
       @links_on_demand = false
       @pagination_links_on_demand = false

--- a/lib/graphiti/configuration.rb
+++ b/lib/graphiti/configuration.rb
@@ -7,7 +7,7 @@ module Graphiti
     # @return [Boolean] Concurrently fetch sideloads?
     #   Defaults to false OR if classes are cached (Rails-only)
     attr_accessor :concurrency
-    
+
     # This number must be considered in accordance with the database
     # connection pool size configured in `database.yml`. The connection
     # pool should be large enough to accommodate both the foreground

--- a/lib/graphiti/scope.rb
+++ b/lib/graphiti/scope.rb
@@ -25,20 +25,20 @@ module Graphiti
       @query = query
       @opts = opts
 
-      @object = @resource.around_scoping(@object, @query.hash) do |scope|
+      @object = @resource.around_scoping(@object, @query.hash) { |scope|
         apply_scoping(scope, opts)
-      end
+      }
     end
 
     def resolve
       if @query.zero_results?
         []
       else
-        resolved = broadcast_data do |payload|
+        resolved = broadcast_data { |payload|
           @object = @resource.before_resolve(@object, @query)
           payload[:results] = @resource.resolve(@object)
           payload[:results]
-        end
+        }
         resolved.compact!
         assign_serializer(resolved)
         yield resolved if block_given?

--- a/lib/graphiti/scope.rb
+++ b/lib/graphiti/scope.rb
@@ -4,7 +4,7 @@ module Graphiti
     attr_reader :pagination
 
     def self.thread_pool_executor
-      concurrency = Graphiti.config.concurrency_pool_max_size || 4
+      concurrency = Graphiti.config.concurrency_max_threads || 4
       @thread_pool_executor ||= Concurrent::ThreadPoolExecutor.new(
         min_threads: 0,
         max_threads: concurrency,

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -150,18 +150,18 @@ RSpec.describe Graphiti::Configuration do
     end
   end
 
-  describe "#concurrency_pool_max_size" do
-    include_context "with config", :concurrency_pool_max_size
+  describe '#concurrency_max_threads' do
+    include_context "with config", :concurrency_max_threads
 
     it "defaults" do
-      expect(Graphiti.config.concurrency_pool_max_size).to eq(4)
+      expect(Graphiti.config.concurrency_max_threads).to eq(4)
     end
 
     it "is overridable" do
       Graphiti.configure do |c|
-        c.concurrency_pool_max_size = 1
+        c.concurrency_max_threads = 1
       end
-      expect(Graphiti.config.concurrency_pool_max_size).to eq(1)
+      expect(Graphiti.config.concurrency_max_threads).to eq(1)
     end
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Graphiti::Configuration do
     end
   end
 
-  describe '#concurrency_max_threads' do
+  describe "#concurrency_max_threads" do
     include_context "with config", :concurrency_max_threads
 
     it "defaults" do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -150,6 +150,21 @@ RSpec.describe Graphiti::Configuration do
     end
   end
 
+  describe "#concurrency_pool_max_size" do
+    include_context "with config", :concurrency_pool_max_size
+
+    it "defaults" do
+      expect(Graphiti.config.concurrency_pool_max_size).to eq(4)
+    end
+
+    it "is overridable" do
+      Graphiti.configure do |c|
+        c.concurrency_pool_max_size = 1
+      end
+      expect(Graphiti.config.concurrency_pool_max_size).to eq(1)
+    end
+  end
+
   describe "#raise_on_missing_sideload" do
     include_context "with config", :raise_on_missing_sideload
 


### PR DESCRIPTION
This option allows to limit the maximum number of resources that can be
sideloaded concurrently. With a properly configured connection pool,
this ensures that the activerecord's connection pool is not exhausted by
the sideloading process.

The thread pool configuration is based on ActiveRecord's
global_thread_pool_async_query_executor.

Closes #469

See: https://github.com/rails/rails/blob/94faed4dd4c915829afc2698e055a0265d9b5773/activerecord/lib/active_record.rb#L279-L287
