### PR TITLE
Fix thread pool scope

### DIFF
--- a/lib/graphiti/scope.rb
+++ b/lib/graphiti/scope.rb
@@ -3,14 +3,14 @@ module Graphiti
     attr_accessor :object, :unpaginated_object
     attr_reader :pagination
 
-    @thread_pool_executor_mutex = Mutex.new
+    @@thread_pool_executor_mutex = Mutex.new
 
     def self.thread_pool_executor
       return @thread_pool_executor if @thread_pool_executor
 
       concurrency = Graphiti.config.concurrency_max_threads || 4
-      @thread_pool_executor ||= @thread_pool_executor_mutex.synchronize do
-        Concurrent::ThreadPoolExecutor.new(
+      @@thread_pool_executor_mutex.synchronize do
+        @@thread_pool_executor ||= Concurrent::ThreadPoolExecutor.new(
           min_threads: 0,
           max_threads: concurrency,
           max_queue: concurrency * 4,


### PR DESCRIPTION
The thread pool and mutex need to be global across instances of Scope for it to be a global thread pool.

See: https://github.com/graphiti-api/graphiti/pull/470