### PR TITLE
Fix standalone requiring

### DIFF
--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -2,8 +2,9 @@ require "json"
 require "forwardable"
 require "uri"
 
+require "active_support/version"
 require "active_support/deprecation"
-require "active_support/deprecator"
+require "active_support/deprecator" if ::ActiveSupport.version >= Gem::Version.new("7.1")
 require "active_support/core_ext/string"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/class/attribute"

--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -1,13 +1,15 @@
 require "json"
 require "forwardable"
 require "uri"
+
+require "active_support/deprecation"
+require "active_support/deprecator"
 require "active_support/core_ext/string"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/class/attribute"
 require "active_support/core_ext/hash/conversions" # to_xml
 require "active_support/concern"
 require "active_support/time"
-require "active_support/deprecation"
 
 require "dry-types"
 require "graphiti_errors"

--- a/lib/graphiti/scope.rb
+++ b/lib/graphiti/scope.rb
@@ -102,7 +102,7 @@ module Graphiti
         Graphiti.log(e)
       end
 
-      return updated_time || Time.now
+      updated_time || Time.now
     end
     alias_method :last_modified_at, :updated_at
 


### PR DESCRIPTION
It seems that right now you cannot simply `require 'graphiti'` without requiring `active_support` prior to it.

You get the following output:
```
...gems/activesupport-7.1.3.4/lib/active_support/core_ext/array/conversions.rb:108:in `<class:Array>': undefined method `deprecator' for module ActiveSupport (NoMethodError)

  deprecate to_default_s: :to_s, deprecator: ActiveSupport.deprecator
                                                          ^^^^^^^^^^^
Did you mean?  deprecate_constant
```

It looks like the problem is caused by the following code:
https://github.com/graphiti-api/graphiti/blob/1479411646a841be56f8dda613b4e9f63ba2b576/lib/graphiti.rb#L4

This PR just places `require "active_support/deprecation"` on top of the list and adds `require "active_support/deprecator"` on the next line to satisfy dependencies which seems to solve the issue

Edit: this issue is probably Rails 7 and newer only due to internal changes in `ActiveSupport`