### PR TITLE
Fix json.rb 2.7.2 compatibility

### DIFF
--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -1,6 +1,7 @@
 require "json"
 require "forwardable"
 require "uri"
+require "ostruct" unless defined?(::OpenStruct)
 
 require "active_support/version"
 require "active_support/deprecation"


### PR DESCRIPTION
Stdlib's `json.rb` now (since version 2.7.2) relies on `GenericObject` which is autoloaded later (see https://github.com/ruby/ruby/blob/9d69619623ec6b86c464b7cac911b7201f74dab7/ext/json/lib/json/common.rb#L5).

This change makes Graphiti unable to be `require`d.

If you try to `require 'graphiti'` you end up with the following error:
```
...gems/graphiti-1.7.2/lib/graphiti/resource/remote.rb:8:in `block in <module:Remote>': uninitialized constant Graphiti::Resource::Remote::OpenStruct (NameError)

        self.model = OpenStruct
                     ^^^^^^^^^^
	from ...gems/activesupport-7.1.3.4/lib/active_support/concern.rb:138:in `class_eval'
	from ...gems/activesupport-7.1.3.4/lib/active_support/concern.rb:138:in `append_features'
	from ...gems/graphiti-1.7.2/lib/graphiti/resource/configuration.rb:48:in `include'
	from ...gems/graphiti-1.7.2/lib/graphiti/resource/configuration.rb:48:in `remote='
```

This PR simply `require`s `OpenStruct` explicitly (if not already loaded). 