### PR TITLE
Fix deprecated call in activerecord adapter

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -304,7 +304,7 @@ module Graphiti
       end
 
       def close
-        ::ActiveRecord::Base.clear_active_connections!
+        ::ActiveRecord::Base.connection_handler.clear_active_connections!
       end
 
       def can_group?


### PR DESCRIPTION
Deprecated call `::ActiveRecord::Base.clear_active_connections!` has been moved to connection_handler.

This was causing our app to fail in production on Rails 7.2.1.

Not sure how well 7.2.1 is supported yet.  Perhaps more PRs to come.