### PR TITLE
Fixes version check for ActiveRecord adapter introduced in #478

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -304,7 +304,7 @@ module Graphiti
       end
 
       def close
-        if ::ActiveRecord.version > 7.2
+        if ::ActiveRecord.version > '7.2'
           ::ActiveRecord::Base.connection_handler.clear_active_connections!
         else
           ::ActiveRecord::Base.clear_active_connections!

--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -304,7 +304,11 @@ module Graphiti
       end
 
       def close
-        ::ActiveRecord::Base.clear_active_connections!
+        if ::ActiveRecord.version > 7.2
+          ::ActiveRecord::Base.connection_handler.clear_active_connections!
+        else
+          ::ActiveRecord::Base.clear_active_connections!
+        end
       end
 
       def can_group?

--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -304,7 +304,7 @@ module Graphiti
       end
 
       def close
-        if ::ActiveRecord.version > '7.2'
+        if ::ActiveRecord.version > "7.2"
           ::ActiveRecord::Base.connection_handler.clear_active_connections!
         else
           ::ActiveRecord::Base.clear_active_connections!


### PR DESCRIPTION
Fixes version check for ActiveRecord version, introduced in #478, that's causing an ArgumentError, as the target version for the comparison is expected to be a String not a Number.

@jkeen  