### PR TITLE
compare URI-decoded path params

### DIFF
--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -190,6 +190,7 @@ require "graphiti/serializer"
 require "graphiti/query"
 require "graphiti/debugger"
 require "graphiti/util/cache_debug"
+require "graphiti/util/uri_decoder"
 
 if defined?(ActiveRecord)
   require "graphiti/adapters/active_record"

--- a/lib/graphiti/adapters/null.rb
+++ b/lib/graphiti/adapters/null.rb
@@ -168,6 +168,14 @@ module Graphiti
         scope
       end
 
+      def filter_uuid_eq(scope, attribute, value)
+        scope
+      end
+
+      def filter_uuid_not_eq(scope, attribute, value)
+        scope
+      end
+
       def base_scope(model)
         {}
       end

--- a/lib/graphiti/resource/links.rb
+++ b/lib/graphiti/resource/links.rb
@@ -76,7 +76,7 @@ module Graphiti
           path = request_path
           if [:update, :show, :destroy].include?(action) && has_id
             path = request_path.split("/")
-            path.pop if URI.decode_uri_component(path.last) == has_id.to_s
+            path.pop if Graphiti::Util::UriDecoder.decode_uri(path.last) == has_id.to_s
             path = path.join("/")
           end
           e[:full_path].to_s == path && e[:actions].include?(action)

--- a/lib/graphiti/resource/links.rb
+++ b/lib/graphiti/resource/links.rb
@@ -74,12 +74,12 @@ module Graphiti
         endpoints.any? do |e|
           has_id = params[:id] || params[:data].try(:[], :id)
           path = request_path
-          if [:update, :show, :destroy].include?(context_namespace) && has_id
+          if [:update, :show, :destroy].include?(action) && has_id
             path = request_path.split("/")
-            path.pop if path.last == has_id.to_s
+            path.pop if URI.decode_uri_component(path.last) == has_id.to_s
             path = path.join("/")
           end
-          e[:full_path].to_s == path && e[:actions].include?(context_namespace)
+          e[:full_path].to_s == path && e[:actions].include?(action)
         end
       end
 

--- a/lib/graphiti/util/uri_decoder.rb
+++ b/lib/graphiti/util/uri_decoder.rb
@@ -1,0 +1,9 @@
+module Graphiti
+  module Util
+    module UriDecoder
+      def self.decode_uri(uri)
+        Graphiti.config.uri_decoder.call(uri)
+      end
+    end
+  end
+end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -1238,6 +1238,23 @@ RSpec.describe Graphiti::Resource do
               end
             end
           end
+
+          context "with a url-encoded path param" do
+            before do
+              request.env["PATH_INFO"] += "/123%3B456"
+
+              klass.instance_exec do
+                attribute :id, :uuid
+              end
+            end
+
+            it "works" do
+              klass
+              Graphiti.with_context ctx, :show do
+                expect { klass.find(id: "123;456") }.to_not raise_error
+              end
+            end
+          end
         end
 
         context "and the request matches a secondary endpoint" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,7 +68,7 @@ end
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2.0")
   unless defined?(::ActionDispatch::Journey)
-    require 'uri'
+    require "uri"
     # NOTE: `decode_www_form_component` isn't an ideal default for production,
     # because it varies slightly compared to typical uri parameterization,
     # but it will allow tests to pass in non-rails contexts.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,3 +64,13 @@ if ENV["APPRAISAL_INITIALIZED"]
     database: ":memory:"
   Dir[File.dirname(__FILE__) + "/fixtures/**/*.rb"].sort.each { |f| require f }
 end
+
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2.0")
+  unless defined?(::ActionDispatch::Journey)
+    require 'uri'
+    # NOTE: `decode_www_form_component` isn't an ideal default for production,
+    # because it varies slightly compared to typical uri parameterization,
+    # but it will allow tests to pass in non-rails contexts.
+    Graphiti.config.uri_decoder = URI.method(:decode_www_form_component)
+  end
+end


### PR DESCRIPTION
Mitigation for a regression introduced in https://github.com/graphiti-api/graphiti/pull/447.

URI-encoded path parameters should be decoded before comparing with the (already-decoded) param.

The URI decoder is automatically set to the rails router decoder when it is detected, or `URI.decode_uri_component` (Ruby >= 3.2). Users on older rubies without Rails can optionally configure it via `Graphiti.config.uri_decoder = -> (uri) { ... }` (but this is only necessary if you are doing endpoint validation for routes that have percent-encoded path parameters).