### PR TITLE
Fix gem version check

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -304,7 +304,7 @@ module Graphiti
       end
 
       def close
-        if ::ActiveRecord.version > "7.2"
+        if ::ActiveRecord.version > Gem::Version.new("7.2")
           ::ActiveRecord::Base.connection_handler.clear_active_connections!
         else
           ::ActiveRecord::Base.clear_active_connections!


### PR DESCRIPTION
All the other places in graphiti that compare against `ActiveRecord.version` are doing it this way for compatibility with new-enough dependencies. This one seems to have been missed. 