### PR TITLE
490 - Fix clear_active_connections deprecation in active_record 7.1

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -304,7 +304,7 @@ module Graphiti
       end
 
       def close
-        if ::ActiveRecord.version > Gem::Version.new("7.2")
+        if ::ActiveRecord.version > Gem::Version.new("7.1")
           ::ActiveRecord::Base.connection_handler.clear_active_connections!
         else
           ::ActiveRecord::Base.clear_active_connections!


### PR DESCRIPTION
Fixes: https://github.com/graphiti-api/graphiti/issues/490

Summary:
Update the conditional check [here](https://github.com/graphiti-api/graphiti/blob/master/lib/graphiti/adapters/active_record.rb#L307) to check for AR version 7.1 instead of 7.2


```
DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_active_connections! is deprecated. Please call the method directly on the connection handler; for example: `ActiveRecord::Base.connection_handler.clear_active_connections!`. (called from clear_active_connections! at /usr/local/bundle/gems/activerecord-7.1.5.1/lib/active_record/connection_handling.rb:320) (ActiveSupport::DeprecationException)
    from gems/graphiti-1.7.6/lib/graphiti/adapters/active_record.rb:310:in `close'
    from gems/graphiti-1.7.6/lib/graphiti/scope.rb:49:in `block (2 levels) in resolve_sideloads'
    from gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/executor/safe_task_executor.rb:24:in `block in execute'
```