### PR TITLE
Lazy constantize relation resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 graphiti changelog
 
+## [1.7.7](https://github.com/graphiti-api/graphiti/compare/v1.7.6...v1.7.7) (2025-03-15)
+
+
+### Bug Fixes
+
+* change class attribute behavior on endpoint method to work in ruby 3.2+ ([#493](https://github.com/graphiti-api/graphiti/issues/493)) ([04f1f3c](https://github.com/graphiti-api/graphiti/commit/04f1f3c783bfe18e6568cc21924d417a82234135))
+
 ## [1.7.6](https://github.com/graphiti-api/graphiti/compare/v1.7.5...v1.7.6) (2024-11-06)
 
 

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -21,7 +21,7 @@ module Graphiti
       @name = name
       validate_options!(opts)
       @parent_resource_class = opts[:parent_resource]
-      @resource_class = opts[:resource]
+      @resource_class_name = opts[:resource]
       @primary_key = opts[:primary_key]
       @foreign_key = opts[:foreign_key]
       @type = opts[:type]
@@ -177,7 +177,7 @@ module Graphiti
     end
 
     def resource_class
-      @cons_resource_class ||= (@resource_class.is_a?(String) ? @resource_class.constantize : @resource_class) ||
+      @resource_class ||= (@resource_class_name.is_a?(String) ? @resource_class_name.constantize : @resource_class_name) ||
         infer_resource_class
     end
 

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -248,11 +248,7 @@ module Graphiti
     end
 
     def resource
-      @resource ||= begin
-                      kl = resource_class
-                      binding.pry if kl.is_a?(String)
-                      kl.new
-                    end
+      @resource ||= resource_class.new
     end
 
     def parent_resource

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -177,7 +177,8 @@ module Graphiti
     end
 
     def resource_class
-      @resource_class ||= infer_resource_class
+      @cons_resource_class ||= (@resource_class.is_a?(String) ? @resource_class.constantize : @resource_class) ||
+        infer_resource_class
     end
 
     def scope(parents)
@@ -247,7 +248,11 @@ module Graphiti
     end
 
     def resource
-      @resource ||= resource_class.new
+      @resource ||= begin
+                      kl = resource_class
+                      binding.pry if kl.is_a?(String)
+                      kl.new
+                    end
     end
 
     def parent_resource

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -225,6 +225,7 @@ module Legacy
   end
 
   class UserResource < ApplicationResource
+    has_many :my_books, resource: 'Legacy::BookResource'
   end
 
   class BookResource < ApplicationResource

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -225,7 +225,7 @@ module Legacy
   end
 
   class UserResource < ApplicationResource
-    has_many :my_books, resource: 'Legacy::BookResource'
+    has_many :my_books, resource: "Legacy::BookResource"
   end
 
   class BookResource < ApplicationResource


### PR DESCRIPTION
When two resources have custom relation names it's hard to specify the resource for those relations because you need both resources to be loaded in memory. Doing it lazily solves the issue. You can specify a string as a resource name and it will be constantized later when needed