### PR TITLE
WIP: Maintain thread context in spawned threads for nested sideloads

### DIFF
--- a/lib/graphiti/scope.rb
+++ b/lib/graphiti/scope.rb
@@ -163,10 +163,10 @@ module Graphiti
             yield(*args)
           end
 
-          if execution_context_changed
-            thread_storage&.keys&.each { |key| Thread.current[key] = nil }
-            fiber_storage&.keys&.each { |key| Fiber[key] = nil }
-          end
+          # if execution_context_changed
+          #   thread_storage&.keys&.each { |key| Thread.current[key] = nil }
+          #   fiber_storage&.keys&.each { |key| Fiber[key] = nil }
+          # end
 
           result
         end


### PR DESCRIPTION
When there are multi-level sideloads, the thread context is not maintained when sideloads spawn sideloads, i.e. when a sideload of "permissions.user" is requested. In practice this makes the context object available in resource methods (used to access controller methods) unavailable.

In my app this was causing intermittent 500 errors when it couldn't access the controller to grab the pundit context. 
@MattFenelon Removing these lines fixes the issue, but I'm not sure if this will cause other unintended problems? 