### PR TITLE
Add cache tags support

### DIFF
--- a/lib/graphiti/resource/interface.rb
+++ b/lib/graphiti/resource/interface.rb
@@ -4,9 +4,10 @@ module Graphiti
       extend ActiveSupport::Concern
 
       class_methods do
-        def cache_resource(expires_in: false)
+        def cache_resource(expires_in: false, tag: nil)
           @cache_resource = true
           @cache_expires_in = expires_in
+          @cache_tag = tag
         end
 
         def all(params = {}, base_scope = nil)
@@ -55,7 +56,7 @@ module Graphiti
         private
 
         def caching_options
-          {cache: @cache_resource, cache_expires_in: @cache_expires_in}
+          { cache: @cache_resource, cache_expires_in: @cache_expires_in, cache_tag: @cache_tag }
         end
 
         def validate_request!(params)

--- a/lib/graphiti/resource/interface.rb
+++ b/lib/graphiti/resource/interface.rb
@@ -56,7 +56,7 @@ module Graphiti
         private
 
         def caching_options
-          { cache: @cache_resource, cache_expires_in: @cache_expires_in, cache_tag: @cache_tag }
+          {cache: @cache_resource, cache_expires_in: @cache_expires_in, cache_tag: @cache_tag}
         end
 
         def validate_request!(params)

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -2,14 +2,19 @@ module Graphiti
   class ResourceProxy
     include Enumerable
 
-    attr_reader :resource, :query, :scope, :payload, :cache_expires_in, :cache
+    attr_reader :resource, :query, :scope, :payload, :cache_expires_in, :cache, :cache_tag
 
-    def initialize(resource, scope, query,
+    def initialize(
+      resource,
+      scope,
+      query,
       payload: nil,
       single: false,
       raise_on_missing: false,
       cache: nil,
-      cache_expires_in: nil)
+      cache_expires_in: nil,
+      cache_tag: nil
+    )
 
       @resource = resource
       @scope = scope
@@ -19,6 +24,7 @@ module Graphiti
       @raise_on_missing = raise_on_missing
       @cache = cache
       @cache_expires_in = cache_expires_in
+      @cache_tag = cache_tag
     end
 
     def cache?
@@ -207,12 +213,30 @@ module Graphiti
       "W/#{ActiveSupport::Digest.hexdigest(cache_key_with_version.to_s)}"
     end
 
+    def resource_cache_tag
+      return unless @cache_tag.present? && @resource.respond_to?(@cache_tag)
+
+      @resource.try(@cache_tag)
+    end
+
     def cache_key
-      ActiveSupport::Cache.expand_cache_key([@scope.cache_key, @query.cache_key])
+      ActiveSupport::Cache.expand_cache_key(
+        [
+          @scope.cache_key,
+          @query.cache_key,
+          resource_cache_tag,
+        ].compact_blank
+      )
     end
 
     def cache_key_with_version
-      ActiveSupport::Cache.expand_cache_key([@scope.cache_key_with_version, @query.cache_key])
+      ActiveSupport::Cache.expand_cache_key(
+        [
+          @scope.cache_key_with_version,
+          @query.cache_key,
+          resource_cache_tag,
+        ].compact_blank
+      )
     end
 
     private

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -224,7 +224,7 @@ module Graphiti
         [
           @scope.cache_key,
           @query.cache_key,
-          resource_cache_tag,
+          resource_cache_tag
         ].compact_blank
       )
     end
@@ -234,7 +234,7 @@ module Graphiti
         [
           @scope.cache_key_with_version,
           @query.cache_key,
-          resource_cache_tag,
+          resource_cache_tag
         ].compact_blank
       )
     end

--- a/lib/graphiti/runner.rb
+++ b/lib/graphiti/runner.rb
@@ -58,22 +58,29 @@ module Graphiti
 
     def proxy(base = nil, opts = {})
       base ||= jsonapi_resource.base_scope
-      scope_opts = opts.slice :sideload_parent_length,
+      scope_opts = opts.slice(
+        :sideload_parent_length,
         :default_paginate,
         :after_resolve,
         :sideload,
         :parent,
         :params,
         :bypass_required_filters
+      )
+
       scope = jsonapi_scope(base, scope_opts)
-      ResourceProxy.new jsonapi_resource,
+
+      ::Graphiti::ResourceProxy.new(
+        jsonapi_resource,
         scope,
         query,
         payload: deserialized_payload,
         single: opts[:single],
         raise_on_missing: opts[:raise_on_missing],
         cache: opts[:cache],
-        cache_expires_in: opts[:cache_expires_in]
+        cache_expires_in: opts[:cache_expires_in],
+        cache_tag: opts[:cache_tag]
+      )
     end
   end
 end

--- a/lib/graphiti/util/cache_debug.rb
+++ b/lib/graphiti/util/cache_debug.rb
@@ -12,7 +12,9 @@ module Graphiti
       end
 
       def name
-        "#{Graphiti.context[:object]&.request&.method} #{Graphiti.context[:object]&.request&.url}"
+        tag = proxy.resource_cache_tag
+
+        "#{::Graphiti.context[:object]&.request&.method} #{::Graphiti.context[:object]&.request&.url} #{tag}"
       end
 
       def key

--- a/spec/resource_proxy_spec.rb
+++ b/spec/resource_proxy_spec.rb
@@ -14,11 +14,18 @@ RSpec.describe Graphiti::ResourceProxy do
     let(:query) { double(cache_key: "query-hash") }
     let(:scope) { double(cache_key: "scope-hash", cache_key_with_version: "scope-hash-123456") }
 
-    subject { described_class.new(resource, scope, query, **{}) }
+    subject { described_class.new(resource, scope, query, **{ cache_tag: :cache_tag }) }
 
-    it "cache_key combines query and scope cache keys" do
+    it "cache_key combines query and scope cache keys if no tags are set" do
       cache_key = subject.cache_key
       expect(cache_key).to eq("scope-hash/query-hash")
+    end
+
+    it "cache_key combines query, scope and tag cache keys if a tag is set" do
+      allow(resource).to receive(:cache_tag).and_return("tag_value")
+
+      cache_key = subject.cache_key
+      expect(cache_key).to eq("scope-hash/query-hash/tag_value")
     end
 
     it "generates stable etag" do

--- a/spec/resource_proxy_spec.rb
+++ b/spec/resource_proxy_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Graphiti::ResourceProxy do
     let(:query) { double(cache_key: "query-hash") }
     let(:scope) { double(cache_key: "scope-hash", cache_key_with_version: "scope-hash-123456") }
 
-    subject { described_class.new(resource, scope, query, **{ cache_tag: :cache_tag }) }
+    subject { described_class.new(resource, scope, query, **{cache_tag: :cache_tag}) }
 
     it "cache_key combines query and scope cache keys if no tags are set" do
       cache_key = subject.cache_key


### PR DESCRIPTION
The original cache implementation relies on two main parts: scope and query.

Quite often we use scoping as a policy-based access control for listing actions like `index`. With Graphiti it is easily achieved by making `#base_scope` context-aware (e.g. like checking a requesting user role and restricting access to certain entities for non-admins). The problem is that it is only represented via changes in the DB query object (we have different cache keys for different scopes since they result in different queries). One of the side effects is that Graphiti has no idea about it and cache debugger stubbornly states lots and lots of cache misses (it associates cache keys with the request info that doesn't include any info from the request context). 

The idea behind this PR is simple: enable cache tagging with a value returned from a resource instance method (that can access request context). This method name has to be passed as a symbol argument to the `cache_resource` resource class method alongside `expires_in` argument.