### PR TITLE
Make parse_fieldset more resilient

### DIFF
--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -302,7 +302,7 @@ module Graphiti
       {}.tap do |hash|
         fieldset.each_pair do |type, fields|
           type = type.to_sym
-          fields = fields.split(",") unless fields.is_a?(Array)
+          fields = fields.to_s.split(",") unless fields.is_a?(Array)
           hash[type] = fields.map(&:to_sym)
         end
       end


### PR DESCRIPTION
Querys with `?fields[model]=` are already handled okay but when omitting `=` it results in an exception. This changes fixes that