### PR TITLE
test: fix order-dependent spec failures

### DIFF
--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -18,9 +18,12 @@ if ENV["APPRAISAL_INITIALIZED"]
       end
     end
 
-    let(:one_day_ago) { 1.day.ago }
-    let(:two_days_ago) { 2.days.ago }
-    let(:one_day_from_now) { 1.day.from_now }
+    # Datetime filters are compared against an iso8601 string, which drops
+    # sub-second precision. Pinning these to whole seconds keeps the fixture
+    # and the filter value from disagreeing about which second they are in.
+    let(:one_day_ago) { 1.day.ago.change(usec: 0) }
+    let(:two_days_ago) { 2.days.ago.change(usec: 0) }
+    let(:one_day_from_now) { 1.day.from_now.change(usec: 0) }
 
     let!(:author1) do
       Legacy::Author.create! first_name: "Stephen",

--- a/spec/sideloading_spec.rb
+++ b/spec/sideloading_spec.rb
@@ -628,6 +628,23 @@ RSpec.describe "sideloading" do
   end
 
   context "when nesting sideloads" do
+    # This context adds sideloads to the shared PORO resources rather than to
+    # an anonymous subclass, so snapshot and restore them - otherwise every
+    # later example in the suite inherits the extra relationships.
+    around do |example|
+      shared = [PORO::EmployeeResource, PORO::PositionResource]
+      snapshot = shared.map { |klass|
+        [klass, klass.config[:sideloads].dup,
+          klass.serializer.relationship_blocks.dup]
+      }
+      example.run
+    ensure
+      snapshot.each do |klass, sideloads, blocks|
+        klass.config[:sideloads] = sideloads
+        klass.serializer.relationship_blocks.replace(blocks)
+      end
+    end
+
     before do
       stub_const(
         "Graphiti::Scope::GLOBAL_THREAD_POOL_EXECUTOR",
@@ -1035,6 +1052,18 @@ RSpec.describe "sideloading" do
         def self.name
           "PORO::PositionResource"
         end
+      end
+    end
+
+    # PORO::Position is shared across the whole suite and defines #department
+    # as an attr_accessor. Overriding it here without restoring leaks into
+    # every later example, where it blows up as soon as no departments exist.
+    around do |example|
+      example.run
+    ensure
+      PORO::Position.class_eval do
+        remove_method :department
+        attr_reader :department
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,18 @@ RSpec.configure do |config|
     end
   end
 
+  # Every anonymous Class.new(SomeResource) registers itself in the global
+  # Graphiti.resources via the inherited hook, and nothing ever removes it.
+  # Graphiti.setup! walks that list and re-applies sideloads, so without this
+  # an example calling setup! reaches back into every throwaway resource
+  # earlier examples defined - which makes results depend on spec order.
+  config.around do |example|
+    registered = Graphiti.resources.dup
+    example.run
+  ensure
+    Graphiti.resources.replace(registered)
+  end
+
   config.filter_run_when_matching :focus
 
   config.example_status_persistence_file_path = File.expand_path(".rspec-examples", __dir__)


### PR DESCRIPTION
Fixes state leaking between examples, which made results depend on spec order.

Test-only — no library code is touched.

## Reproducing (on `main`, before this branch)

```
bundle exec rspec              # 1374 examples, 0 failures  ← default order passes
bundle exec rspec --seed 1     # 4 failures
bundle exec rspec --seed 999   # 5 failures
bundle exec rspec --seed 4242  # 10 failures
```

Counts are exactly reproducible per seed. Every failing example passes in isolation.

This is the source of the intermittent CI failures — a job occasionally fails while the other 50 pass, on unchanged code.

## Three leaks

**1. `PORO::Position#department` is monkeypatched with no teardown** (`sideloading_spec.rb`)

`PORO::Position` is shared suite-wide and defines `department` as an `attr_accessor`. A `before` block overrode it permanently, so every later example inherited the override — and it raises as soon as no departments exist:

```
NoMethodError: undefined method `each_pair' for nil
  ./spec/fixtures/poro.rb:139:in `initialize'
  ./spec/sideloading_spec.rb:1044:in `department'   ← leaked into an unrelated file
```

Restored in an `around`.

**2. Sideloads added to the shared resource classes** (`sideloading_spec.rb`)

`PORO::EmployeeResource.class_eval` / `PORO::PositionResource.class_eval` added relationships to the *shared* classes rather than an anonymous subclass. Later contexts do `Class.new(PORO::PositionResource)` and inherit the leftovers, which is why the three `via_belongs_to` specs returned `[1, 2]` where they expect `[2]`.

Snapshotted and restored, including the serializer's `relationship_blocks` — `apply_sideload_to_serializer` mutates the serializer in place.

**3. `Graphiti.resources` is an unbounded global registry** (`spec_helper.rb`)

Every `Class.new(SomeResource)` registers itself via the `inherited` hook and is never removed. `Graphiti.setup!` walks that list:

```ruby
def self.setup!
  resources.each { |r| r.apply_sideloads_to_serializer }
end
```

So any example calling `setup!` reaches back into every throwaway resource defined by every earlier example and re-applies its sideloads. This is what fixes 1 and 2 couldn't reach (`resource_spec.rb:88`, `serialization_spec.rb:764`/`:776`).

Snapshot/restore around each example.

## Also: a flaky datetime filter spec

`finders_spec.rb` "when a datetime / nothing / defaults to eq" has failed on CI with `expected: [2], got: []`.

Datetime filters compare against an `iso8601` string, which drops sub-second precision, so the fixture and the filter value can disagree about which second they're in. The time fixtures are now pinned to whole seconds with `.change(usec: 0)`.

Note: this one could not be reproduced locally (30 consecutive runs passed, and the boundary math checks out on Ruby 3.3 / Rails 8). The observed failure was on rails_7. This is hardening against the failure mode rather than a confirmed root cause.

## Verification

| | before | after |
|---|---|---|
| `--seed 1` | 4 failures | 0 |
| `--seed 999` | 5 failures | 0 |
| `--seed 4242` | 10 failures | 0 |
| `--seed 7`, `--seed 12345` | — | 0 |

Default order 1374/0, rails integration 270/0, standardrb clean.

## Follow-up worth considering

Adding `--order random` to `.rspec` would keep this from regressing, at the cost of a non-deterministic baseline. Left out deliberately — worth its own discussion.
