### PR TITLE
perf: skip promise machinery when concurrency is disabled

### DIFF
--- a/lib/graphiti/scope.rb
+++ b/lib/graphiti/scope.rb
@@ -42,11 +42,20 @@ module Graphiti
       }
     end
 
-    def resolve
+    def resolve(&blk)
+      # When concurrency is disabled, take a synchronous path that mirrors the
+      # pre-1.8 semantics. This avoids allocating Concurrent::Promises futures,
+      # Thread/Fiber storage snapshots, and Rails executor wrappers on every
+      # request purely to drive a thread pool that is intentionally synchronous.
+      # See https://github.com/graphiti-api/graphiti/issues/505
+      return sync_resolve(&blk) unless Graphiti.config.concurrency
+
       future_resolve.value!
     end
 
     def resolve_sideloads(results)
+      return sync_resolve_sideloads(results) unless Graphiti.config.concurrency
+
       future_resolve_sideloads(results).value!
     end
 
@@ -112,6 +121,43 @@ module Graphiti
     alias_method :last_modified_at, :updated_at
 
     private
+
+    # Synchronous counterpart to #future_resolve, used when concurrency is off.
+    # Resolves the resource and its sideloads inline without any promise
+    # machinery. See #resolve.
+    def sync_resolve
+      return [] if @query.zero_results?
+
+      resolved = broadcast_data { |payload|
+        @object = @resource.before_resolve(@object, @query)
+        payload[:results] = @resource.resolve(@object)
+        payload[:results]
+      }
+      resolved.compact!
+      assign_serializer(resolved)
+      yield resolved if block_given?
+      @opts[:after_resolve]&.call(resolved)
+      sync_resolve_sideloads(resolved) unless @query.sideloads.empty?
+      resolved
+    end
+
+    # Synchronous counterpart to #future_resolve_sideloads, used when
+    # concurrency is off. Resolves each sideload inline. See #resolve_sideloads.
+    def sync_resolve_sideloads(results)
+      return if results == []
+
+      @query.sideloads.each_pair do |name, q|
+        sideload = @resource.class.sideload(name)
+        next if sideload.nil? || sideload.shared_remote?
+
+        Graphiti.config.before_sideload&.call(Graphiti.context)
+        sideload.resolve(results, q, @resource)
+      end
+
+      # Match pre-1.8 semantics: the non-concurrent resolve_sideloads returned
+      # nil (not the sideloads Hash). Callers don't rely on the return value.
+      nil
+    end
 
     def future_resolve_sideloads(results)
       return Concurrent::Promises.fulfilled_future(nil, self.class.global_thread_pool_executor) if results == []

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -236,6 +236,8 @@ module Graphiti
     end
 
     def load(parents, query, graph_parent)
+      return build_resource_proxy(parents, query, graph_parent).to_a unless Graphiti.config.concurrency
+
       future_load(parents, query, graph_parent).value!
     end
 
@@ -284,6 +286,33 @@ module Graphiti
         end
       end
       children.replace(associated) if track_associated
+    end
+
+    # Synchronous counterpart to #future_resolve, used when concurrency is off.
+    # Mirrors #future_resolve but resolves inline via the synchronous
+    # Scope#resolve / #load paths (no promises). See Scope#sync_resolve_sideloads.
+    def resolve(parents, query, graph_parent)
+      return future_resolve(parents, query, graph_parent).value! if Graphiti.config.concurrency
+
+      if single? && parents.length > 1
+        raise Errors::SingularSideload.new(self, parents.length)
+      end
+
+      if self.class.scope_proc
+        sideload_scope = fire_scope(parents)
+        sideload_scope = Scope.new sideload_scope,
+          resource,
+          query,
+          parent: graph_parent,
+          sideload: self,
+          sideload_parent_length: parents.length,
+          default_paginate: false
+        sideload_scope.resolve do |sideload_results|
+          fire_assign(parents, sideload_results)
+        end
+      else
+        load(parents, query, graph_parent)
+      end
     end
 
     def future_resolve(parents, query, graph_parent)

--- a/lib/graphiti/sideload/polymorphic_belongs_to.rb
+++ b/lib/graphiti/sideload/polymorphic_belongs_to.rb
@@ -108,7 +108,20 @@ class Graphiti::Sideload::PolymorphicBelongsTo < Graphiti::Sideload::BelongsTo
   end
 
   def resolve(parents, query, graph_parent)
-    future_resolve(parents, query, graph_parent).value!
+    return future_resolve(parents, query, graph_parent).value! if Graphiti.config.concurrency
+
+    parents.group_by(&grouper.field_name).each_pair do |group_name, group|
+      next if group_name.nil? || grouper.ignore?(group_name)
+
+      match = ->(c) { c.group_name == group_name.to_sym }
+      if (sideload = children.values.find(&match))
+        duped = remove_invalid_sideloads(sideload.resource, query)
+        sideload.resolve(group, duped, graph_parent)
+      else
+        err = ::Graphiti::Errors::PolymorphicSideloadChildNotFound
+        raise err.new(self, group_name)
+      end
+    end
   end
 
   def future_resolve(parents, query, graph_parent)

--- a/spec/scope_spec.rb
+++ b/spec/scope_spec.rb
@@ -44,10 +44,21 @@ RSpec.describe Graphiti::Scope do
           allow(resource.class).to receive(:sideload).with(:positions) { sideload }
         end
 
-        it "resolves the sideload" do
-          expect(sideload).to receive(:future_resolve)
-            .with(results, query.sideloads[:positions], resource) { Concurrent::Promises.future {} }
+        it "resolves the sideload synchronously by default" do
+          expect(sideload).to receive(:resolve)
+            .with(results, query.sideloads[:positions], resource)
+          expect(sideload).not_to receive(:future_resolve)
           instance.resolve
+        end
+
+        context "when Graphiti.config.concurrency is true" do
+          before { allow(Graphiti.config).to receive(:concurrency).and_return(true) }
+
+          it "resolves the sideload via a future" do
+            expect(sideload).to receive(:future_resolve)
+              .with(results, query.sideloads[:positions], resource) { Concurrent::Promises.future {} }
+            instance.resolve
+          end
         end
 
         context "but no parents were found" do
@@ -121,6 +132,9 @@ RSpec.describe Graphiti::Scope do
         context "when Graphiti.config.concurrency is false" do
           before do
             allow(Graphiti.config).to receive(:concurrency).and_return(false)
+            allow(sideload).to receive(:resolve) do |_results, q, _parent_resource|
+              described_class.new(double.as_null_object, position_resource, q).resolve
+            end
           end
 
           it "does not close db connections" do
@@ -158,8 +172,8 @@ RSpec.describe Graphiti::Scope do
         end
 
         it "resolves the sideload" do
-          expect(sideload).to receive(:future_resolve)
-            .with(results, query.sideloads[:positions], resource) { Concurrent::Promises.future {} }
+          expect(sideload).to receive(:resolve)
+            .with(results, query.sideloads[:positions], resource)
           instance.resolve_sideloads(results)
         end
 
@@ -278,7 +292,7 @@ RSpec.describe Graphiti::Scope do
           before { allow(Graphiti.config).to receive(:concurrency).and_return(false) }
 
           it "does not close db connection" do
-            allow(sideload).to receive(:future_resolve) { Concurrent::Promises.future {} }
+            allow(sideload).to receive(:resolve)
 
             expect(resource.adapter).not_to receive(:close)
             instance.resolve_sideloads(results)
@@ -287,7 +301,7 @@ RSpec.describe Graphiti::Scope do
           it "does not clear thread locals" do
             Thread.current[:foo] = "bar"
 
-            allow(sideload).to receive(:future_resolve) { Concurrent::Promises.fulfilled_future({}) }
+            allow(sideload).to receive(:resolve)
             instance.resolve_sideloads(results)
 
             expect(Thread.current[:foo]).to eq("bar")
@@ -297,7 +311,7 @@ RSpec.describe Graphiti::Scope do
             it "does not clear fiber locals" do
               Fiber[:foo] = "bar"
 
-              allow(sideload).to receive(:future_resolve) { Concurrent::Promises.fulfilled_future({}) }
+              allow(sideload).to receive(:resolve)
               instance.resolve_sideloads(results)
 
               expect(Fiber[:foo]).to eq("bar")
@@ -315,29 +329,59 @@ RSpec.describe Graphiti::Scope do
         end
 
         context "when the first sideload errors" do
-          before do
-            allow(sideload).to receive(:future_resolve) do
-              Concurrent::Promises.future { raise "danger will robinson!" }
+          context "without concurrency" do
+            before do
+              allow(sideload).to receive(:resolve) { raise "danger will robinson!" }
+            end
+
+            it "raises the error" do
+              expect { instance.resolve_sideloads(results) }.to raise_error("danger will robinson!")
             end
           end
 
-          it "raises the error" do
-            expect { instance.resolve_sideloads(results) }.to raise_error("danger will robinson!")
+          context "with concurrency" do
+            before do
+              allow(Graphiti.config).to receive(:concurrency).and_return(true)
+              allow(sideload).to receive(:future_resolve) do
+                Concurrent::Promises.future { raise "danger will robinson!" }
+              end
+            end
+
+            it "raises the error" do
+              expect { instance.resolve_sideloads(results) }.to raise_error("danger will robinson!")
+            end
           end
         end
 
-        context "when another sideload errors" do
+        context "when a later sideload errors" do
           let(:sideload_2) { double("visas", shared_remote?: false, name: :visas) }
           let(:params) { {include: {positions: {}, visas: {}}} }
 
           before do
             allow(resource.class).to receive(:sideload).with(:visas) { sideload_2 }
-            allow(sideload).to receive(:future_resolve) { Concurrent::Promises.future {} }
-            allow(sideload_2).to receive(:future_resolve) { Concurrent::Promises.future { raise "sideload_2" } }
           end
 
-          it "raises the error" do
-            expect { instance.resolve_sideloads(results) }.to raise_error("sideload_2")
+          context "without concurrency" do
+            before do
+              allow(sideload).to receive(:resolve)
+              allow(sideload_2).to receive(:resolve) { raise "sideload_2" }
+            end
+
+            it "raises the error" do
+              expect { instance.resolve_sideloads(results) }.to raise_error("sideload_2")
+            end
+          end
+
+          context "with concurrency" do
+            before do
+              allow(Graphiti.config).to receive(:concurrency).and_return(true)
+              allow(sideload).to receive(:future_resolve) { Concurrent::Promises.future {} }
+              allow(sideload_2).to receive(:future_resolve) { Concurrent::Promises.future { raise "sideload_2" } }
+            end
+
+            it "raises the error" do
+              expect { instance.resolve_sideloads(results) }.to raise_error("sideload_2")
+            end
           end
         end
 
@@ -347,12 +391,29 @@ RSpec.describe Graphiti::Scope do
 
           before do
             allow(resource.class).to receive(:sideload).with(:visas) { sideload_2 }
-            allow(sideload).to receive(:future_resolve) { Concurrent::Promises.future { raise "sideload" } }
-            allow(sideload_2).to receive(:future_resolve) { Concurrent::Promises.future { raise "sideload_2" } }
           end
 
-          it "raises the first error" do
-            expect { instance.resolve_sideloads(results) }.to raise_error("sideload")
+          context "without concurrency" do
+            before do
+              allow(sideload).to receive(:resolve) { raise "sideload" }
+              allow(sideload_2).to receive(:resolve) { raise "sideload_2" }
+            end
+
+            it "raises the first error" do
+              expect { instance.resolve_sideloads(results) }.to raise_error("sideload")
+            end
+          end
+
+          context "with concurrency" do
+            before do
+              allow(Graphiti.config).to receive(:concurrency).and_return(true)
+              allow(sideload).to receive(:future_resolve) { Concurrent::Promises.future { raise "sideload" } }
+              allow(sideload_2).to receive(:future_resolve) { Concurrent::Promises.future { raise "sideload_2" } }
+            end
+
+            it "raises the first error" do
+              expect { instance.resolve_sideloads(results) }.to raise_error("sideload")
+            end
           end
         end
       end

--- a/spec/sideload/polymorphic_belongs_to_spec.rb
+++ b/spec/sideload/polymorphic_belongs_to_spec.rb
@@ -45,4 +45,34 @@ RSpec.describe Graphiti::Sideload::PolymorphicBelongsTo do
       expect(instance.child_for_type("bars")).to eq(child2)
     end
   end
+
+  describe "#resolve" do
+    let(:query) { double("query") }
+    let(:graph_parent) { double("graph_parent") }
+    let(:parent) { double("parent", credit_card_id: "credit_cards") }
+    let(:parents) { [parent] }
+    let(:child_sideload) { double("child", group_name: :credit_cards, resource: double("resource")) }
+
+    before do
+      allow(instance.grouper).to receive(:field_name).and_return(:credit_card_id)
+      instance.children = {credit_cards: child_sideload}
+      allow(instance).to receive(:remove_invalid_sideloads) { query }
+    end
+
+    it "resolves each group synchronously by default" do
+      expect(instance).not_to receive(:future_resolve)
+      expect(child_sideload).to receive(:resolve).with(parents, query, graph_parent)
+      instance.resolve(parents, query, graph_parent)
+    end
+
+    context "when Graphiti.config.concurrency is true" do
+      before { allow(Graphiti.config).to receive(:concurrency).and_return(true) }
+
+      it "resolves via a future" do
+        expect(instance).to receive(:future_resolve)
+          .with(parents, query, graph_parent).and_return(Concurrent::Promises.fulfilled_future(nil))
+        instance.resolve(parents, query, graph_parent)
+      end
+    end
+  end
 end

--- a/spec/sideload_spec.rb
+++ b/spec/sideload_spec.rb
@@ -653,6 +653,21 @@ RSpec.describe Graphiti::Sideload do
       expect(records).to eq(results)
     end
 
+    it "loads synchronously without a future by default" do
+      expect(instance).not_to receive(:future_load)
+      expect(instance.load(parents, query, nil)).to eq(results)
+    end
+
+    context "when Graphiti.config.concurrency is true" do
+      before { allow(Graphiti.config).to receive(:concurrency).and_return(true) }
+
+      it "loads via a future" do
+        expect(instance).to receive(:future_load)
+          .with(parents, query, nil).and_return(Concurrent::Promises.fulfilled_future(results))
+        expect(instance.load(parents, query, nil)).to eq(results)
+      end
+    end
+
     context "when params customization" do
       before do
         instance.class.params do |hash, parents, context|


### PR DESCRIPTION
# Skip promise machinery when concurrency is disabled

Fixes #505

## Problem

Since the `Concurrent::Promises` rewrite in 1.8.0 (#472, extended by #497 in
1.8.2), every request allocates promise machinery even when
`Graphiti.config.concurrency` is `false` — which is the default. On each
request Graphiti now:

- allocates `Concurrent::Promises::Future` objects plus `then_on` /
  `zip_futures_on` / `rescue_on` chains, and
- snapshots `Thread.current` storage and `Fiber.current` storage into new
  Hashes, once per sideload, and
- wraps the work in a `Rails.application.executor` block.

For an app that does not enable concurrency, this is pure overhead: the
allocations exist only to drive a thread pool that is intentionally configured
as synchronous (`max_threads: 0, synchronous: true`). The cost scales with the
number of sideloads per request, and in production it shows up as increased
object allocation and GC frequency.

Measured on a small Rails JSON:API service hitting an endpoint with one
sideload (stock config, `concurrency = false`):

| Configuration | Total allocations / request | concurrent-ruby memory / 20 reqs |
|---|---:|---:|
| graphiti **1.7.9** | 10,369 | 6.40 kB |
| graphiti **1.10.2** (stock) | 10,666 (**+297, +2.9%**) | **309.60 kB** |
| graphiti **1.10.2 + this change** | 10,365 (**-4**) | **6.40 kB** |

With concurrency off, the allocation profile returns to the 1.7.9 baseline.

## Change

Branch on `Graphiti.config.concurrency` at the public entry points and dispatch
to a synchronous path when concurrency is disabled:

- `Scope#resolve` → `sync_resolve`
- `Scope#resolve_sideloads` → `sync_resolve_sideloads`
- `Sideload#load` → `build_resource_proxy(...).to_a`
- `Sideload#resolve` (new synchronous sibling of `future_resolve`)
- `Sideload::PolymorphicBelongsTo#resolve` → synchronous group-by

The synchronous path mirrors the pre-1.8 (1.7.9) semantics — no `Future`
allocation, no thread/fiber storage snapshots — while reusing the existing 1.10
helpers (`broadcast_data`, `assign_serializer`, `before_resolve`,
`after_resolve`, `before_sideload`).

**The `future_*` methods are left completely untouched**, so applications with
`concurrency = true` get the existing 1.8+ behavior byte-for-byte. The branch
is a single `return ... if/unless Graphiti.config.concurrency` guard at the top
of each entry point.

## Notes on behavior parity

- `sync_resolve_sideloads` returns `nil`, matching the pre-1.8
  `resolve_sideloads` return value (no caller relies on the return value).
- Under concurrency off, sideload errors surface from the first failing
  sideload (sequential), matching 1.7.9. The concurrent path still evaluates
  all sideload futures and re-raises the first error via `rescue_on`,
  unchanged.

## Tests

Existing specs updated so the default (concurrency off) cases assert the
synchronous dispatch, and new `concurrency = true` sub-contexts were added to
keep the future path covered at every branch point — including the
`resolve_sideloads` error-aggregation cases (first / later / multiple sideloads
error), which are exercised on both paths. Full suite passes.
