### PR TITLE
feat: pass the model and attribute name to writable guards

### DIFF
--- a/lib/graphiti/request_validators/validator.rb
+++ b/lib/graphiti/request_validators/validator.rb
@@ -83,20 +83,22 @@ module Graphiti
       end
 
       def typecast_attributes(resource, attributes, action, payload_path)
-        attributes.each_pair do |key, value|
-          # Only validate id if create action, otherwise it's only used for lookup
-          next if action != :create &&
-            key == :id &&
-            resource.class.config[:attributes][:id][:writable] == false
+        resource.with_guarded_write(action, attributes[:id]) do
+          attributes.each_pair do |key, value|
+            # Only validate id if create action, otherwise it's only used for lookup
+            next if action != :create &&
+              key == :id &&
+              resource.class.config[:attributes][:id][:writable] == false
 
-          begin
-            attributes[key] = resource.typecast(key, value, :writable)
-          rescue Graphiti::Errors::UnknownAttribute
-            @errors.add(fully_qualified_key(key, payload_path), :unknown_attribute, message: "is an unknown attribute")
-          rescue Graphiti::Errors::InvalidAttributeAccess
-            @errors.add(fully_qualified_key(key, payload_path), :unwritable_attribute, message: "cannot be written")
-          rescue Graphiti::Errors::TypecastFailed => e
-            @errors.add(fully_qualified_key(key, payload_path), :type_error, message: "should be type #{e.type_name}")
+            begin
+              attributes[key] = resource.typecast(key, value, :writable)
+            rescue Graphiti::Errors::UnknownAttribute
+              @errors.add(fully_qualified_key(key, payload_path), :unknown_attribute, message: "is an unknown attribute")
+            rescue Graphiti::Errors::InvalidAttributeAccess
+              @errors.add(fully_qualified_key(key, payload_path), :unwritable_attribute, message: "cannot be written")
+            rescue Graphiti::Errors::TypecastFailed => e
+              @errors.add(fully_qualified_key(key, payload_path), :type_error, message: "should be type #{e.type_name}")
+            end
           end
         end
       end

--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -67,6 +67,32 @@ module Graphiti
       adapter.base_scope(model)
     end
 
+    # Exposes write context to attribute guards for the duration of the block.
+    # @api private
+    def with_guarded_write(action, id)
+      @guarded_write = {action: action, id: id}
+      yield
+    ensure
+      remove_instance_variable(:@guarded_write) if defined?(@guarded_write)
+      remove_instance_variable(:@guard_model) if defined?(@guard_model)
+    end
+
+    # The model a writable guard is being asked about. Resolved lazily and
+    # memoized, so it costs nothing unless a guard asks for it, and is only
+    # resolved once per payload. On create, this is a new unsaved instance.
+    # @api private
+    def guard_model
+      return @guard_model if defined?(@guard_model)
+
+      @guard_model = if !defined?(@guarded_write)
+        nil
+      elsif @guarded_write[:action] == :create || @guarded_write[:id].nil?
+        build(model)
+      else
+        self.class._find(id: @guarded_write[:id]).data
+      end
+    end
+
     def typecast(name, value, flag)
       att = get_attr!(name, flag, request: true)
       type_name = att[:type]

--- a/lib/graphiti/util/attribute_check.rb
+++ b/lib/graphiti/util/attribute_check.rb
@@ -50,14 +50,41 @@ module Graphiti
         end
       end
 
+      # Guards may optionally accept the model being written and the attribute
+      # name, mirroring readable guards.
       def guard_passes?
-        !!resource.send(attribute[flag])
+        result = case guard_arity
+        when 0 then call_guard
+        when 1 then call_guard(resource.guard_model)
+        else call_guard(resource.guard_model, name.to_s)
+        end
+        !!result
+      end
+
+      def call_guard(*args)
+        if guard.is_a?(Proc)
+          resource.instance_exec(*args, &guard)
+        else
+          resource.send(guard, *args)
+        end
+      end
+
+      def guard_arity
+        method = guard.is_a?(Proc) ? guard : resource.method(guard)
+        # Negative arity means optional or splatted params - hand over
+        # everything and let the guard take what it wants.
+        method.arity.negative? ? 2 : method.arity
+      end
+
+      def guard
+        attribute[flag]
       end
 
       def guarded?
-        request? &&
-          attribute[flag].is_a?(Symbol) &&
-          attribute[flag] != :required
+        return false unless request?
+        return false if guard == :required
+
+        guard.is_a?(Symbol) || guard.is_a?(String) || guard.is_a?(Proc)
       end
 
       def supported?

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -165,6 +165,49 @@ if ENV["APPRAISAL_INITIALIZED"]
           }.to raise_error(Graphiti::Errors::ConflictRequest)
         end
       end
+
+      # A writable guard can accept the model being written, so policy objects
+      # can make per-record decisions. On update that is the persisted record,
+      # loaded before the incoming attributes are applied.
+      context "when a writable guard accepts the model" do
+        let(:guard_arguments) { [] }
+
+        before do
+          captured = guard_arguments
+          guarded = Class.new(EmployeeResource) do
+            def self.name
+              "EmployeeResource"
+            end
+
+            attribute :first_name, :string, writable: :editable?
+
+            define_method(:editable?) do |record, attribute_name|
+              captured << [record, attribute_name]
+              record.first_name != "locked"
+            end
+          end
+          allow(controller).to receive(:resource) { guarded }
+        end
+
+        it "receives the persisted record and the attribute name" do
+          make_request
+          record, attribute_name = guard_arguments.first
+          expect(record).to be_a(Employee)
+          expect(record.id).to eq(employee.id)
+          expect(record.first_name).to eq("Joe")
+          expect(attribute_name).to eq("first_name")
+        end
+
+        context "and the guard rejects the record" do
+          let(:employee) { Employee.create(first_name: "locked") }
+
+          it "refuses the write" do
+            expect { make_request }
+              .to raise_error(Graphiti::Errors::InvalidRequest)
+            expect(employee.reload.first_name).to eq("locked")
+          end
+        end
+      end
     end
 
     describe "basic destroy" do

--- a/spec/request_validator_spec.rb
+++ b/spec/request_validator_spec.rb
@@ -139,6 +139,95 @@ RSpec.describe Graphiti::RequestValidator do
             expect(instance.errors).to be_blank
           end
         end
+
+        # The point of resolving lazily: a guard that doesn't ask for a model
+        # must not cause one to be built or loaded.
+        context "and the guard takes no arguments" do
+          it "is not handed a model" do
+            expect(root_resource).to_not receive(:guard_model)
+            validate
+          end
+        end
+
+        context "and the guard takes the model" do
+          before do
+            root_resource_class.attribute :salary, :integer,
+              writable: :salary_writable?, readable: false
+            root_resource_class.class_eval do
+              def salary_writable?(model)
+                model.first_name != "locked"
+              end
+            end
+          end
+
+          it "is handed the model under write" do
+            expect(validate).to eq true
+            expect(instance.errors).to be_blank
+          end
+
+          context "and the guard rejects it" do
+            before do
+              allow(root_resource).to receive(:guard_model)
+                .and_return(PORO::Employee.new(first_name: "locked"))
+            end
+
+            it "has an unwritable attribute error" do
+              expect(validate).to eq false
+              expect(instance.errors)
+                .to be_added(:'data.attributes.salary', :unwritable_attribute)
+            end
+          end
+        end
+
+        context "and the guard takes the model and attribute name" do
+          before do
+            root_resource_class.attribute :salary, :integer,
+              writable: :salary_writable?, readable: false
+            root_resource_class.class_eval do
+              attr_reader :guarded_with
+
+              def salary_writable?(model, attribute_name)
+                @guarded_with = [model, attribute_name]
+                true
+              end
+            end
+          end
+
+          it "receives both" do
+            expect(validate).to eq true
+            model, attribute_name = root_resource.guarded_with
+            expect(model).to be_a(PORO::Employee)
+            expect(attribute_name).to eq("salary")
+          end
+        end
+
+        context "and the guard is a string" do
+          before do
+            root_resource_class.attribute :salary, :integer,
+              writable: "admin?", readable: false
+            allow(root_resource).to receive(:admin?).and_return(false)
+          end
+
+          it "is still applied" do
+            expect(validate).to eq false
+            expect(instance.errors)
+              .to be_added(:'data.attributes.salary', :unwritable_attribute)
+          end
+        end
+
+        context "and the guard is a proc" do
+          before do
+            root_resource_class.attribute :salary, :integer,
+              writable: -> { admin? }, readable: false
+            allow(root_resource).to receive(:admin?).and_return(false)
+          end
+
+          it "is still applied" do
+            expect(validate).to eq false
+            expect(instance.errors)
+              .to be_added(:'data.attributes.salary', :unwritable_attribute)
+          end
+        end
       end
 
       context "when the payload contains fields needing typecasting" do


### PR DESCRIPTION
Writable guards can now receive the model being written and the name of the guarded attribute, mirroring what readable guards have long supported at render time. This resolves the remaining piece of #481 

```ruby
attribute :salary, :integer, writable: :salary_writable?

def salary_writable?(model, attribute_name)
  PolicyChecker.new(model).attribute_writable?(attribute_name)
end
```

Dispatch is arity-based, just like the readable guards: zero parameters is called as before, one receives the model, two receive both. Symbols, strings, and procs all work.

A few deliberate choices:

- **The guard sees the pre-write state** — a fresh find on update, a new unsaved instance on create. That's what a policy object expects for "may this user touch this attribute", not a validation of the incoming values.
- **The model resolves lazily and memoizes** — many guarded attributes cost at most one find, and zero-arg guards pay nothing (spec-enforced).

Fully backwards compatible: existing guards all have arity zero and dispatch identically to today. 