### PR TITLE
fix: improve InvalidEndpoint guidance

### DIFF
--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -445,6 +445,12 @@ module Graphiti
 
           secondary_endpoint '/my_url', [:index, :update]
 
+          Or disable endpoint validation for this resource:
+
+          self.validate_endpoints = false
+
+          See https://www.graphiti.dev/guides/concepts/links for more information.
+
           The current endpoints allowed for this resource are: #{@resource_class.endpoints.inspect}
         MSG
       end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -1274,11 +1274,15 @@ RSpec.describe Graphiti::Resource do
             klass.primary_endpoint "/api/v1/employees", [:create]
           end
 
-          it "raises error" do
+          it "raises error with endpoint configuration guidance" do
             Graphiti.with_context ctx, :index do
               expect {
                 klass.all
-              }.to raise_error(Graphiti::Errors::InvalidEndpoint, /QueryAllSpec::EmployeeResource cannot be called directly from endpoint \/api\/v1\/employees/)
+              }.to raise_error(Graphiti::Errors::InvalidEndpoint) { |error|
+                expect(error.message).to include("QueryAllSpec::EmployeeResource cannot be called directly from endpoint /api/v1/employees")
+                expect(error.message).to include("self.validate_endpoints = false")
+                expect(error.message).to include("https://www.graphiti.dev/guides/concepts/links")
+              }
             end
           end
 


### PR DESCRIPTION
## Summary

- show the `self.validate_endpoints = false` escape valve in `InvalidEndpoint` errors
- link the error message to Graphiti's endpoint documentation
- strengthen the existing request-context spec to cover both recovery hints

This gives developers an immediate path to either configure the endpoint correctly or intentionally disable validation.

Closes #149

## Validation

- `bundle exec rspec spec/resource_spec.rb` — 141 examples, 0 failures
- `bundle exec rspec` — passed
- `bundle exec standardrb --no-fix --format progress` — 170 files, no offenses
- `git diff --check` — passed

AI assistance disclosure: This contribution was prepared with OpenAI Codex assistance. The final diff and validation results were reviewed before submission.
