### PR TITLE
feat: deprecate mutating attributes in around_persistence hooks [skip ci]

### DIFF
--- a/lib/graphiti/resource/persistence.rb
+++ b/lib/graphiti/resource/persistence.rb
@@ -71,8 +71,11 @@ module Graphiti
 
       def create(create_params, meta = nil)
         model_instance = nil
+        snapshot = attributes_snapshot(:create, create_params)
 
         run_callbacks :persistence, :create, create_params, meta do
+          warn_attributes_mutated_in_around_persistence(:create, snapshot, create_params)
+
           run_callbacks :attributes, :create, create_params, meta do |params|
             model_instance = call_with_meta(:build, model, meta)
             call_with_meta(:assign_attributes, model_instance, params, meta)
@@ -92,7 +95,11 @@ module Graphiti
         id = update_params[:id]
         update_params = update_params.except(:id)
 
+        snapshot = attributes_snapshot(:update, update_params)
+
         run_callbacks :persistence, :update, update_params, meta do
+          warn_attributes_mutated_in_around_persistence(:update, snapshot, update_params)
+
           run_callbacks :attributes, :update, update_params, meta do |params|
             model_instance = self.class._find(id: id).data
             call_with_meta(:assign_attributes, model_instance, params, meta)
@@ -132,6 +139,37 @@ module Graphiti
       end
 
       private
+
+      # In Graphiti 2.0, attributes are assigned to the model before the
+      # persistence hooks fire, so hash modifications made by an
+      # around_persistence hook before its yield will no longer be applied.
+      # Snapshot-and-compare detects exactly those hooks: the comparison
+      # happens before any attributes-phase callback has run, so hooks that
+      # only wrap their yield never trigger the warning.
+      def attributes_snapshot(action, params)
+        return unless around_persistence_hooks?(action)
+        Util::Hash.deep_dup(params)
+      end
+
+      def around_persistence_hooks?(action)
+        hooks = self.class.config[:callbacks][:persistence].try(:[], :around) || []
+        hooks.any? { |hook| hook[:only].include?(action) }
+      end
+
+      def warn_attributes_mutated_in_around_persistence(action, snapshot, params)
+        return if snapshot.nil? || snapshot == params
+
+        changed_keys = (snapshot.keys | params.keys).reject { |key| snapshot[key] == params[key] }
+        Graphiti::DEPRECATOR.warn(<<~MSG)
+          #{self.class}'s around_persistence hook modified the attributes hash before yield (changed keys: #{changed_keys.map(&:inspect).join(", ")}). In Graphiti 2.0, attributes are assigned to the model before persistence hooks run, and these modifications will be silently ignored. Move the modification to a hook that runs before assignment:
+
+            before_attributes do |attributes|
+              attributes[#{changed_keys.first.inspect}] = ...
+            end
+
+          or set the value on the model itself in a before_save hook. See UPGRADING.md in the Graphiti 2.0 release.
+        MSG
+      end
 
       def run_callbacks(kind, action, *args)
         fire_around_callbacks(kind, action, *args) do |*yieldargs|

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -727,6 +727,60 @@ RSpec.describe "persistence" do
 
         include_examples "around persistence", only_update: true
       end
+
+      describe "deprecation of pre-yield attribute mutation" do
+        context "when a hook modifies the attributes hash before yield" do
+          before do
+            klass.class_eval do
+              around_persistence :do_around_persistence
+
+              def do_around_persistence(attributes)
+                attributes[:first_name] = "b4"
+                yield
+              end
+            end
+          end
+
+          it "warns on create, naming the changed keys" do
+            expect(Graphiti::DEPRECATOR).to receive(:warn)
+              .with(/around_persistence hook modified the attributes hash before yield \(changed keys: :first_name\)/)
+            klass.build(payload).save
+          end
+
+          it "warns on update" do
+            employee = PORO::Employee.create(first_name: "asdf")
+            payload[:data][:id] = employee.id.to_s
+
+            expect(Graphiti::DEPRECATOR).to receive(:warn).with(/before yield/)
+            klass.find(payload).update_attributes
+          end
+        end
+
+        context "when a hook only wraps its yield" do
+          before do
+            klass.class_eval do
+              around_persistence :do_around_persistence
+
+              def do_around_persistence(attributes)
+                model = yield
+                model.update_attributes(first_name: "#{model.first_name}after")
+              end
+            end
+          end
+
+          it "does not warn" do
+            expect(Graphiti::DEPRECATOR).not_to receive(:warn)
+            klass.build(payload).save
+          end
+        end
+
+        context "when no around_persistence hook is registered" do
+          it "does not warn" do
+            expect(Graphiti::DEPRECATOR).not_to receive(:warn)
+            klass.build(payload).save
+          end
+        end
+      end
     end
 
     describe ".around_save" do


### PR DESCRIPTION
Graphiti 2.0 will assign attributes to the model before persistence hooks fire, so pre-yield hash modifications will be ignored. Warn now, naming the changed keys