### PR TITLE
fix: typecast null values in filter lists

### DIFF
--- a/lib/graphiti/scoping/filter.rb
+++ b/lib/graphiti/scoping/filter.rb
@@ -209,7 +209,9 @@ module Graphiti
     end
 
     def parse_string_null(filter, value)
-      return if value == "null" && filter[:allow_nil]
+      return value unless filter[:allow_nil]
+      return value.map { |item| item == "null" ? nil : item } if value.is_a?(Array)
+      return if value == "null"
 
       value
     end

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -296,6 +296,17 @@ RSpec.describe "filtering" do
       it "works" do
         expect(records.map(&:id)).to eq([employee2.id])
       end
+
+      context "with comma-delimited values" do
+        before do
+          employee3.update_attributes(first_name: "Lucy")
+          params[:filter] = {first_name: "null,Lucy"}
+        end
+
+        it "typecasts null to nil" do
+          expect(records.map(&:id)).to eq([employee2.id, employee3.id])
+        end
+      end
     end
 
     context "with integer type" do


### PR DESCRIPTION
## Summary

- typecast `null` entries inside comma-delimited filter values when `allow_nil` is enabled
- preserve existing behavior for filters that do not allow nil values
- add a regression spec covering `filter[name]=null,Lucy`

Fixes #411

## Verification

- `bundle exec rspec spec/filtering_spec.rb`
- `bundle exec rspec`
- `bundle exec standardrb`
- `git diff --check`