### PR TITLE
fix: accept a single value for array filters

### DIFF
--- a/lib/graphiti/types.rb
+++ b/lib/graphiti/types.rb
@@ -82,6 +82,10 @@ module Graphiti
       Dry::Types["params.hash"][input]
     }
 
+    ParamArray = Dry::Types["strict.array"].constructor { |input|
+      input.is_a?(String) ? [input] : input
+    }
+
     REQUIRED_KEYS = [:params, :read, :write, :kind, :description]
 
     def self.map
@@ -193,7 +197,7 @@ module Graphiti
 
           arrays[:"array_of_#{name.to_s.pluralize}"] = {
             canonical_name: name,
-            params: Dry::Types["strict.array"].of(map[:params]),
+            params: ParamArray.of(map[:params]),
             read: Dry::Types["strict.array"].of(map[:read]),
             test: Dry::Types["strict.array"].of(map[:test]),
             write: Dry::Types["strict.array"].of(map[:write]),

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -1272,6 +1272,17 @@ RSpec.describe "filtering" do
       end
     end
 
+    context "when array_of_strings" do
+      before do
+        resource.attribute :foo, :array_of_strings
+      end
+
+      it "wraps a single query value" do
+        params[:filter] = {foo: "Beef"}
+        assert_filter_value(["Beef"])
+      end
+    end
+
     # test for all array_of_*
     context "when array_of_integers" do
       before do


### PR DESCRIPTION
Allows array filters to accept one query value by wrapping a scalar string before element coercion. The focused filtering specs and StandardRB pass. Fixes #370.