### PR TITLE
fix: reject invalid page parameters

### DIFF
--- a/lib/graphiti/request_validators/validator.rb
+++ b/lib/graphiti/request_validators/validator.rb
@@ -11,10 +11,12 @@ module Graphiti
       end
 
       def validate
+        validate_page
+
         # Right now, all requests - even reads - go through the validator
         # In the future these should have their own validation logic, but
         # for now we can just bypass
-        return true unless @params.has_key?(:data)
+        return errors.blank? unless @params.has_key?(:data)
 
         resource = @root_resource
 
@@ -47,6 +49,13 @@ module Graphiti
       end
 
       private
+
+      def validate_page
+        page = @params[:page]
+        return if page.nil? || page.respond_to?(:each_pair)
+
+        @errors.add(:page, :invalid, message: "must be an object")
+      end
 
       def process_relationships(resource, relationships, payload_path)
         relationships.each_key do |name|

--- a/spec/request_validator_spec.rb
+++ b/spec/request_validator_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe Graphiti::RequestValidator do
       end
     end
 
+    context "when page is not an object" do
+      let(:payload) { {page: "1"} }
+
+      it "adds a page error" do
+        expect(validate).to eq false
+        expect(instance.errors).to be_added(:page, :invalid)
+        expect(instance.errors.full_messages).to eq ["page must be an object"]
+      end
+
+      it "raises InvalidRequest when using validate!" do
+        expect {
+          instance.validate!
+        }.to raise_error(Graphiti::Errors::InvalidRequest, /page must be an object/)
+      end
+    end
+
     context "when missing type" do
       let(:payload) do
         {


### PR DESCRIPTION
closes #347

`page=1` currently reaches `Query#pagination`, which assumes `page` responds to `each_pair` and raises a `NoMethodError`.

this validates `page` at the existing request-validator boundary before read requests bypass payload validation. non-object values now produce `Graphiti::Errors::InvalidRequest` with `page must be an object`, while omitted and hash-shaped page parameters keep their existing behavior.

checks:
- `bundle exec rspec spec/request_validator_spec.rb spec/query_spec.rb` (103 examples, 0 failures)
- `bundle exec standardrb lib/graphiti/request_validators/validator.rb spec/request_validator_spec.rb`
- `git diff --check`