### PR TITLE
fix: treat empty polymorphic configuration as unset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/.rspec-examples
 spec/dummy/log/*
 *~
 .vscode/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ spec/.rspec-examples
 spec/dummy/log/*
 *~
 .vscode/
-.DS_Store

--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -21,6 +21,10 @@ module Graphiti
           send(:prepend, Polymorphism)
         end
 
+        def polymorphic?
+          polymorphic.present?
+        end
+
         def type=(val)
           val = val&.to_sym
           if (val = super)

--- a/lib/graphiti/resource/polymorphism.rb
+++ b/lib/graphiti/resource/polymorphism.rb
@@ -8,6 +8,8 @@ module Graphiti
       end
 
       def serializer_for(model)
+        return super unless self.class.polymorphic?
+
         if polymorphic_child?
           serializer
         else
@@ -17,10 +19,14 @@ module Graphiti
       end
 
       def associate_all(*args)
+        return super unless self.class.polymorphic?
+
         _associate(:associate_all, *args)
       end
 
       def associate(*args)
+        return super unless self.class.polymorphic?
+
         _associate(:associate, *args)
       end
 
@@ -34,6 +40,8 @@ module Graphiti
 
       module ClassMethods
         def inherited(klass)
+          return super unless polymorphic?
+
           klass.type = nil
           klass.model = klass.infer_model
           klass.endpoint = klass.infer_endpoint
@@ -42,6 +50,8 @@ module Graphiti
         end
 
         def sideload(name)
+          return super unless polymorphic?
+
           if (split_on = name.to_s.split(/^on__/)).length > 1
             on_type, name = split_on[1].split("--").map(&:to_sym)
           end

--- a/spec/polymorphism_spec.rb
+++ b/spec/polymorphism_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "polymorphic resource behavior" do
       context "when unknown model returned" do
         around do |e|
           original = PORO::CreditCardResource.polymorphic
-          PORO::CreditCardResource.polymorphic = []
+          PORO::CreditCardResource.polymorphic = [PORO::VisaResource]
           begin
             e.run
           ensure
@@ -67,6 +67,24 @@ RSpec.describe "polymorphic resource behavior" do
           expect {
             resource.all.to_a
           }.to raise_error(Graphiti::Errors::PolymorphicResourceChildNotFound)
+        end
+      end
+
+      context "when no subclasses are configured" do
+        around do |e|
+          original = PORO::CreditCardResource.polymorphic
+          PORO::CreditCardResource.polymorphic = []
+          begin
+            e.run
+          ensure
+            PORO::CreditCardResource.polymorphic = original
+          end
+        end
+
+        it "behaves like a non-polymorphic resource" do
+          expect(PORO::CreditCardResource).not_to be_polymorphic
+          expect { resource.all.to_a }.not_to raise_error
+          expect(resource.new.serializer_for(mastercard)).to eq(resource.serializer)
         end
       end
     end


### PR DESCRIPTION
## Summary

- make an empty `polymorphic` collection report as non-polymorphic
- delegate already-prepended polymorphism hooks to normal resource behavior when the collection becomes empty
- preserve the unknown-child regression with a genuinely partial child list

This also handles the case raised in the issue discussion where a previously populated collection later becomes empty: the behavior checks the current collection rather than relying only on assignment time.

Fixes #199

## Validation

- `bundle exec rspec spec/polymorphism_spec.rb` — 18 examples, 0 failures
- `bundle exec rspec` — 1,421 examples, 0 failures, 21 pending
- `bundle exec standardrb` — passed
